### PR TITLE
Introduce the basic upgrade reconciliation and condition logic

### DIFF
--- a/api/v1alpha1/release_types.go
+++ b/api/v1alpha1/release_types.go
@@ -63,6 +63,9 @@ type ReleaseSpec struct {
 	Version string `json:"version"`
 	// Registry specifies an OCI registry to fetch release metadata from.
 	Registry string `json:"registry"`
+	// DisableDrain specifies whether nodes drain should be disabled.
+	// +optional
+	DisableDrain bool `json:"disableDrain"`
 }
 
 // ReleaseStatus defines the observed state of Release

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -39,6 +39,7 @@ import (
 	lifecyclev1alpha1 "github.com/suse/elemental-lifecycle-manager/api/v1alpha1"
 	"github.com/suse/elemental-lifecycle-manager/internal/controller"
 	"github.com/suse/elemental-lifecycle-manager/internal/release"
+	"github.com/suse/elemental-lifecycle-manager/internal/upgrade"
 	webhookv1alpha1 "github.com/suse/elemental-lifecycle-manager/internal/webhook/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
@@ -169,6 +170,7 @@ func main() {
 		Client:           mgr.GetClient(),
 		Scheme:           mgr.GetScheme(),
 		RetrieveManifest: release.RetrieveManifest,
+		Pipeline:         upgrade.NewPipeline(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "Release")
 		os.Exit(1)

--- a/config/crd/bases/lifecycle.suse.com_releases.yaml
+++ b/config/crd/bases/lifecycle.suse.com_releases.yaml
@@ -39,6 +39,10 @@ spec:
           spec:
             description: spec defines the desired state of Release
             properties:
+              disableDrain:
+                description: DisableDrain specifies whether nodes drain should be
+                  disabled.
+                type: boolean
               registry:
                 description: Registry specifies an OCI registry to fetch release metadata
                   from.

--- a/internal/controller/condition.go
+++ b/internal/controller/condition.go
@@ -1,0 +1,136 @@
+/*
+Copyright © 2026 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"errors"
+	"fmt"
+
+	lifecyclev1alpha1 "github.com/suse/elemental-lifecycle-manager/api/v1alpha1"
+	"github.com/suse/elemental-lifecycle-manager/internal/upgrade"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func setCondition(release *lifecyclev1alpha1.Release, conditionType string, status metav1.ConditionStatus, reason, message string) {
+	apimeta.SetStatusCondition(&release.Status.Conditions, metav1.Condition{
+		Type:               conditionType,
+		Status:             status,
+		ObservedGeneration: release.Generation,
+		Reason:             reason,
+		Message:            message,
+	})
+}
+
+// initializePendingConditions sets pending conditions for both the manifest and upgrade phases.
+func initializePendingConditions(release *lifecyclev1alpha1.Release, phases []upgrade.Phase) {
+	existing := apimeta.FindStatusCondition(release.Status.Conditions, lifecyclev1alpha1.ConditionManifestResolved)
+	if existing == nil {
+		setCondition(release, lifecyclev1alpha1.ConditionManifestResolved, metav1.ConditionFalse,
+			lifecyclev1alpha1.UpgradePending, "Waiting for release manifest to be resolved")
+	}
+
+	for _, phase := range phases {
+		conditionType := phase.ConditionType()
+		existing := apimeta.FindStatusCondition(release.Status.Conditions, conditionType)
+		if existing == nil {
+			setCondition(release, conditionType, metav1.ConditionFalse,
+				lifecyclev1alpha1.UpgradePending, "Waiting for previous phases to complete")
+		}
+	}
+}
+
+// setPhaseConditionFromError sets a failed condition based on a PhaseError.
+func setPhaseConditionFromError(release *lifecyclev1alpha1.Release, err error) {
+	var phaseErr *upgrade.PhaseError
+	if errors.As(err, &phaseErr) {
+		setCondition(release, phaseErr.Phase.ConditionType(), metav1.ConditionFalse,
+			lifecyclev1alpha1.UpgradeFailed, phaseErr.Err.Error())
+	}
+}
+
+// updatePhaseConditions updates the conditions for all phases from the reconciliation result.
+func updatePhaseConditions(release *lifecyclev1alpha1.Release, result *upgrade.Result) {
+	for phase, state := range result.PhaseStates {
+		updatePhaseCondition(release, phase, state)
+	}
+}
+
+// updatePhaseCondition updates the condition for a phase based on its observed status.
+func updatePhaseCondition(release *lifecyclev1alpha1.Release, phase upgrade.Phase, state *upgrade.PhaseStatus) {
+	conditionType := phase.ConditionType()
+	conditionStatus := metav1.ConditionFalse
+
+	if state.State == lifecyclev1alpha1.UpgradeSucceeded || state.State == lifecyclev1alpha1.UpgradeSkipped {
+		// Only update if not already succeeded or skipped to preserve timestamp
+		existing := apimeta.FindStatusCondition(release.Status.Conditions, conditionType)
+		if existing != nil && existing.Status == metav1.ConditionTrue {
+			return
+		}
+		conditionStatus = metav1.ConditionTrue
+	}
+
+	setCondition(release, conditionType, conditionStatus, state.State, state.Message)
+}
+
+// updateAppliedCondition sets the Applied condition based on all phase conditions.
+func updateAppliedCondition(release *lifecyclev1alpha1.Release, phases []upgrade.Phase) {
+	// Check if manifest is retrieved
+	manifestCond := apimeta.FindStatusCondition(release.Status.Conditions, lifecyclev1alpha1.ConditionManifestResolved)
+	if manifestCond == nil || manifestCond.Status != metav1.ConditionTrue {
+		setCondition(release, lifecyclev1alpha1.ConditionApplied, metav1.ConditionFalse,
+			lifecyclev1alpha1.UpgradeFailed, "Manifest not retrieved")
+		return
+	}
+
+	allSucceeded := true
+	var failedPhase, inProgressPhase string
+
+	for _, phase := range phases {
+		conditionType := phase.ConditionType()
+		cond := apimeta.FindStatusCondition(release.Status.Conditions, conditionType)
+		if cond == nil {
+			allSucceeded = false
+			continue
+		}
+
+		if cond.Status != metav1.ConditionTrue {
+			allSucceeded = false
+			if cond.Reason == lifecyclev1alpha1.UpgradeFailed {
+				failedPhase = conditionType
+			} else if cond.Reason == lifecyclev1alpha1.UpgradeInProgress && inProgressPhase == "" {
+				inProgressPhase = conditionType
+			}
+		}
+	}
+
+	switch {
+	case allSucceeded:
+		setCondition(release, lifecyclev1alpha1.ConditionApplied, metav1.ConditionTrue,
+			lifecyclev1alpha1.UpgradeSucceeded, "All upgrade phases completed successfully")
+	case failedPhase != "":
+		setCondition(release, lifecyclev1alpha1.ConditionApplied, metav1.ConditionFalse,
+			lifecyclev1alpha1.UpgradeFailed, fmt.Sprintf("Phase %s failed", failedPhase))
+	case inProgressPhase != "":
+		setCondition(release, lifecyclev1alpha1.ConditionApplied, metav1.ConditionFalse,
+			lifecyclev1alpha1.UpgradeInProgress, fmt.Sprintf("Phase %s is in progress", inProgressPhase))
+	default:
+		setCondition(release, lifecyclev1alpha1.ConditionApplied, metav1.ConditionFalse,
+			lifecyclev1alpha1.UpgradePending, "Upgrade pending")
+	}
+}

--- a/internal/controller/release_controller.go
+++ b/internal/controller/release_controller.go
@@ -135,7 +135,7 @@ func (r *ReleaseReconciler) reconcileNormal(ctx context.Context, release *lifecy
 	updatePhaseConditions(release, result)
 
 	if result.AllComplete() {
-		release.Status.Version = config.Version
+		release.Status.Version = config.ReleaseVersion
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/controller/release_controller.go
+++ b/internal/controller/release_controller.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
@@ -92,9 +93,6 @@ func (r *ReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	return result, nil
 }
 
-// TODO: remove linter skip once function begins to actually return errors
-//
-//nolint:unparam
 func (r *ReleaseReconciler) reconcileNormal(ctx context.Context, release *lifecyclev1alpha1.Release) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("Upgrade to the platform requested",
@@ -104,20 +102,22 @@ func (r *ReleaseReconciler) reconcileNormal(ctx context.Context, release *lifecy
 	if release.Status.ObservedGeneration != release.Generation {
 		release.Status.ObservedGeneration = release.Generation
 		release.Status.Conditions = nil
-		// TODO: re-initialise 'Pending' conditions
+		initializePendingConditions(release, r.Pipeline.Phases())
 
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	// TODO: update 'Applied' condition
+	defer updateAppliedCondition(release, r.Pipeline.Phases())
 
 	manifest, err := r.getOrRetrieveManifest(ctx, release)
 	if err != nil {
-		// TODO: Set manifest failed condition
+		setCondition(release, lifecyclev1alpha1.ConditionManifestResolved, metav1.ConditionFalse,
+			lifecyclev1alpha1.UpgradeFailed, fmt.Sprintf("Failed to retrieve release manifest: %v", err))
 		return ctrl.Result{}, fmt.Errorf("retrieving release manifest: %w", err)
 	}
 
-	// TODO: Set manifest succeeded condition
+	setCondition(release, lifecyclev1alpha1.ConditionManifestResolved, metav1.ConditionTrue,
+		lifecyclev1alpha1.UpgradeSucceeded, "Release manifest retrieved successfully")
 
 	config, err := r.parseUpgradeConfig(ctx, manifest, release)
 	if err != nil {
@@ -132,7 +132,7 @@ func (r *ReleaseReconciler) reconcileNormal(ctx context.Context, release *lifecy
 		return ctrl.Result{}, fmt.Errorf("reconciling upgrade: %w", err)
 	}
 
-	// TODO: update necessary conditions
+	updatePhaseConditions(release, result)
 
 	if result.AllComplete() {
 		release.Status.Version = config.Version

--- a/internal/controller/release_controller.go
+++ b/internal/controller/release_controller.go
@@ -33,7 +33,9 @@ import (
 
 	lifecyclev1alpha1 "github.com/suse/elemental-lifecycle-manager/api/v1alpha1"
 	releasecache "github.com/suse/elemental-lifecycle-manager/internal/release"
+	"github.com/suse/elemental-lifecycle-manager/internal/upgrade"
 	"github.com/suse/elemental/v3/pkg/manifest/resolver"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const requeueInterval = 30 * time.Second
@@ -44,6 +46,7 @@ type ReleaseReconciler struct {
 	Scheme *runtime.Scheme
 
 	RetrieveManifest func(ctx context.Context, registry, version string) (*resolver.ResolvedManifest, error)
+	Pipeline         *upgrade.Pipeline
 }
 
 // +kubebuilder:rbac:groups=lifecycle.suse.com,resources=releases,verbs=get;list;watch;create;update;patch;delete
@@ -108,16 +111,34 @@ func (r *ReleaseReconciler) reconcileNormal(ctx context.Context, release *lifecy
 
 	// TODO: update 'Applied' condition
 
-	_, err := r.getOrRetrieveManifest(ctx, release)
+	manifest, err := r.getOrRetrieveManifest(ctx, release)
 	if err != nil {
 		// TODO: Set manifest failed condition
 		return ctrl.Result{}, fmt.Errorf("retrieving release manifest: %w", err)
 	}
 
 	// TODO: Set manifest succeeded condition
-	// TODO: parse configuration options from manifest
-	// TODO: call upgrade specific reconcilers
+
+	config, err := r.parseUpgradeConfig(ctx, manifest, release)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("parsing upgrade config: %w", err)
+	}
+
+	// TODO: cleanup SUC Plans for previous release
+
+	result, err := r.Pipeline.Reconcile(ctx, config)
+	if err != nil {
+		setPhaseConditionFromError(release, err)
+		return ctrl.Result{}, fmt.Errorf("reconciling upgrade: %w", err)
+	}
+
 	// TODO: update necessary conditions
+
+	if result.AllComplete() {
+		release.Status.Version = config.Version
+		return ctrl.Result{}, nil
+	}
+
 	return ctrl.Result{RequeueAfter: requeueInterval}, nil
 }
 
@@ -160,6 +181,47 @@ func (r *ReleaseReconciler) getOrRetrieveManifest(ctx context.Context, release *
 	}
 
 	return manifest, nil
+}
+
+func (r *ReleaseReconciler) parseDrainOpts(ctx context.Context, release *lifecyclev1alpha1.Release) (*upgrade.DrainOpts, error) {
+	if release.Spec.DisableDrain {
+		return &upgrade.DrainOpts{ControlPlane: false, Worker: false}, nil
+	}
+
+	nodeList := &corev1.NodeList{}
+	if err := r.List(ctx, nodeList); err != nil {
+		return nil, fmt.Errorf("listing nodes: %w", err)
+	}
+
+	var controlPlaneCounter, workerCounter int
+	for _, node := range nodeList.Items {
+		// TODO: move control-plane label under 'plan' package when SUC plan logic is introduced
+		if _, isControlPlane := node.Labels["node-role.kubernetes.io/control-plane"]; isControlPlane {
+			controlPlaneCounter++
+		} else {
+			workerCounter++
+		}
+	}
+
+	switch {
+	case controlPlaneCounter > 1 && workerCounter <= 1:
+		return &upgrade.DrainOpts{ControlPlane: true, Worker: false}, nil
+	case controlPlaneCounter == 1 && workerCounter > 1:
+		return &upgrade.DrainOpts{ControlPlane: false, Worker: true}, nil
+	case controlPlaneCounter <= 1 && workerCounter <= 1:
+		return &upgrade.DrainOpts{ControlPlane: false, Worker: false}, nil
+	default:
+		return &upgrade.DrainOpts{ControlPlane: true, Worker: true}, nil
+	}
+}
+
+func (r *ReleaseReconciler) parseUpgradeConfig(ctx context.Context, manifest *resolver.ResolvedManifest, release *lifecyclev1alpha1.Release) (config *upgrade.Config, err error) {
+	opts, err := r.parseDrainOpts(ctx, release)
+	if err != nil {
+		return nil, fmt.Errorf("parsing drain options: %w", err)
+	}
+
+	return upgrade.NewConfig(manifest, release.Spec.Version, types.NamespacedName{Name: release.Name, Namespace: release.Namespace}, opts)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/release_controller_test.go
+++ b/internal/controller/release_controller_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -29,57 +30,84 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	lifecyclev1alpha1 "github.com/suse/elemental-lifecycle-manager/api/v1alpha1"
+	"github.com/suse/elemental-lifecycle-manager/internal/upgrade"
+	"github.com/suse/elemental/v3/pkg/manifest/api"
+	"github.com/suse/elemental/v3/pkg/manifest/api/core"
+	"github.com/suse/elemental/v3/pkg/manifest/resolver"
 )
 
 var _ = Describe("Release Controller", func() {
 	Context("When reconciling a resource", func() {
 		const resourceName = "test-resource"
+		var typeNamespacedName types.NamespacedName
+		var defaultCtx context.Context
+		var defaultManifestRetrieve func(ctx context.Context, registry, version string) (*resolver.ResolvedManifest, error)
+		var defaultPipeline *upgrade.Pipeline
+		var defaultReconciler *ReleaseReconciler
+		var defaultRelease *lifecyclev1alpha1.Release
 
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
-		}
 		release := &lifecyclev1alpha1.Release{}
 
 		BeforeEach(func() {
 			By("creating the custom resource for the Kind Release")
-			err := k8sClient.Get(ctx, typeNamespacedName, release)
+			defaultCtx = context.Background()
+			typeNamespacedName = types.NamespacedName{
+				Name:      resourceName,
+				Namespace: "default",
+			}
+
+			defaultRelease = &lifecyclev1alpha1.Release{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: lifecyclev1alpha1.ReleaseSpec{
+					Version:  "0.0.0",
+					Registry: "https://foo.bar.com",
+				}}
+
+			err := k8sClient.Get(defaultCtx, typeNamespacedName, release)
 			if err != nil && errors.IsNotFound(err) {
-				resource := &lifecyclev1alpha1.Release{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      resourceName,
-						Namespace: "default",
+				Expect(k8sClient.Create(defaultCtx, defaultRelease)).To(Succeed())
+			}
+
+			defaultManifestRetrieve = func(_ context.Context, _, _ string) (*resolver.ResolvedManifest, error) { //nolint:unparam
+
+				return &resolver.ResolvedManifest{
+					CorePlatform: &core.ReleaseManifest{
+						Metadata: &api.Metadata{},
+						Components: core.Components{
+							OperatingSystem: &core.OperatingSystem{},
+							Kubernetes:      &core.Kubernetes{},
+						},
 					},
-					// TODO(user): Specify other spec details if needed.
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				}, nil
+			}
+
+			defaultPipeline = upgrade.NewPipeline()
+
+			defaultReconciler = &ReleaseReconciler{
+				Client:           k8sClient,
+				Scheme:           k8sClient.Scheme(),
+				RetrieveManifest: defaultManifestRetrieve,
+				Pipeline:         defaultPipeline,
 			}
 		})
 
 		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
 			resource := &lifecyclev1alpha1.Release{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			err := k8sClient.Get(defaultCtx, typeNamespacedName, resource)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Cleanup the specific resource instance Release")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			Expect(k8sClient.Delete(defaultCtx, resource)).To(Succeed())
 		})
 		It("should successfully reconcile the resource", func() {
 			By("Reconciling the created resource")
-			controllerReconciler := &ReleaseReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+			_, err := defaultReconciler.Reconcile(defaultCtx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
 		})
 	})
 })

--- a/internal/upgrade/config.go
+++ b/internal/upgrade/config.go
@@ -30,8 +30,8 @@ import (
 type Config struct {
 	// ReleaseNamespacedName is the name and namespace of the Release resource.
 	ReleaseNamespacedName types.NamespacedName
-	// Version is the target release version.
-	Version string
+	// ReleaseVersion is the target release version.
+	ReleaseVersion string
 	// OS contains all upgrade configurations related to the target operating system.
 	OS *OSConfig
 	// Kubernetes contains all upgrade configurations related to the target Kubernetes distribution.
@@ -89,7 +89,7 @@ func NewConfig(manifest *resolver.ResolvedManifest, releaseVersion string, relea
 	core := manifest.CorePlatform
 	config := &Config{
 		ReleaseNamespacedName: releaseNamespacedName,
-		Version:               releaseVersion,
+		ReleaseVersion:        releaseVersion,
 		OS: &OSConfig{
 			Image:     core.Components.OperatingSystem.Image.Base,
 			Version:   parseImageTag(core.Components.OperatingSystem.Image.Base),

--- a/internal/upgrade/config.go
+++ b/internal/upgrade/config.go
@@ -1,0 +1,154 @@
+/*
+Copyright © 2026 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/suse/elemental/v3/pkg/manifest/api"
+	"github.com/suse/elemental/v3/pkg/manifest/resolver"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// Config represents a complete upgrade specification for all phases.
+type Config struct {
+	// ReleaseNamespacedName is the name and namespace of the Release resource.
+	ReleaseNamespacedName types.NamespacedName
+	// Version is the target release version.
+	Version string
+	// OS contains all upgrade configurations related to the target operating system.
+	OS *OSConfig
+	// Kubernetes contains all upgrade configurations related to the target Kubernetes distribution.
+	Kubernetes *KubernetesConfig
+	// HelmCharts contains all target Helm charts that need to be upgraded.
+	HelmCharts *HelmChartConfig
+}
+
+// OSConfig contains configurations related to a specific operating system upgrade.
+type OSConfig struct {
+	// Image is the target OS image.
+	Image string
+	// Version is the target OS version.
+	Version string
+	// DrainOpts specifies which nodes should be drained before upgrading the operating system.
+	DrainOpts *DrainOpts
+}
+
+// KubernetesConfig contains configurations related to a specific target Kubernetes distribution.
+type KubernetesConfig struct {
+	// Image is the target Kubernetes distribution image.
+	Image string
+	// Version is the target Kubernetes distribution version.
+	Version string
+	// DrainOpts specifies which nodes should be drained before upgrading the Kubernetes distribution.
+	DrainOpts *DrainOpts
+}
+
+// DrainOpts contains options for draining specific node types
+type DrainOpts struct {
+	// ControlPlane specifies that control plane nodes need to be drained
+	ControlPlane bool
+	// Worker specifies that worker nodes need to be drained
+	Worker bool
+}
+
+// HelmChartConfig contains configuration for Helm Controller HelmChart resources.
+type HelmChartConfig struct {
+	// Charts is the list of Helm charts to deploy/upgrade.
+	Charts []*api.HelmChart
+	// Repositories is the list of Helm repositories.
+	Repositories []*api.HelmRepository
+}
+
+// NewConfig constructs a release upgrade specification from the given data.
+func NewConfig(manifest *resolver.ResolvedManifest, releaseVersion string, releaseNamespacedName types.NamespacedName, drainOpts *DrainOpts) (*Config, error) {
+	if manifest == nil {
+		return nil, fmt.Errorf("manifest is nil")
+	}
+
+	if manifest.CorePlatform == nil {
+		return nil, fmt.Errorf("core platform manifest is required")
+	}
+
+	core := manifest.CorePlatform
+	config := &Config{
+		ReleaseNamespacedName: releaseNamespacedName,
+		Version:               releaseVersion,
+		OS: &OSConfig{
+			Image:     core.Components.OperatingSystem.Image.Base,
+			Version:   parseImageTag(core.Components.OperatingSystem.Image.Base),
+			DrainOpts: drainOpts,
+		},
+	}
+
+	config.Kubernetes = &KubernetesConfig{
+		Image:     core.Components.Kubernetes.Image,
+		Version:   core.Components.Kubernetes.Version,
+		DrainOpts: drainOpts,
+	}
+
+	if manifest.ProductExtension == nil {
+		config.HelmCharts = helmChartConfig(core.Components.Helm, nil)
+	} else {
+		product := manifest.ProductExtension
+		config.HelmCharts = helmChartConfig(core.Components.Helm, product.Components.Helm)
+	}
+
+	return config, nil
+}
+
+// helmChartConfig merges Helm configurations from core and product manifests.
+func helmChartConfig(core, product *api.Helm) *HelmChartConfig {
+	config := &HelmChartConfig{
+		Charts:       make([]*api.HelmChart, 0),
+		Repositories: make([]*api.HelmRepository, 0),
+	}
+
+	// Add core charts and repositories
+	if core != nil {
+		config.Charts = append(config.Charts, core.Charts...)
+		config.Repositories = append(config.Repositories, core.Repositories...)
+	}
+
+	// Add product charts and repositories
+	if product != nil {
+		config.Charts = append(config.Charts, product.Charts...)
+		config.Repositories = append(config.Repositories, product.Repositories...)
+	}
+
+	if len(config.Charts) == 0 && len(config.Repositories) == 0 {
+		return nil
+	}
+
+	return config
+}
+
+func parseImageTag(image string) string {
+	i := strings.LastIndex(image, ":")
+
+	// Find the last slash to ensure the colon we found
+	// isn't just a port number in the registry URL
+	lastSlash := strings.LastIndex(image, "/")
+
+	if i == -1 || i < lastSlash {
+		return "latest"
+	}
+
+	return image[i+1:]
+}

--- a/internal/upgrade/phase.go
+++ b/internal/upgrade/phase.go
@@ -1,0 +1,81 @@
+/*
+Copyright © 2026 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"fmt"
+	"strings"
+
+	lifecyclev1alpha1 "github.com/suse/elemental-lifecycle-manager/api/v1alpha1"
+)
+
+// Phase represents a distinct upgrade phase.
+type Phase string
+
+// Phase constants derived from condition types.
+var (
+	PhaseOS         = Phase(strings.TrimSuffix(lifecyclev1alpha1.ConditionOSUpgraded, "Upgraded"))
+	PhaseKubernetes = Phase(strings.TrimSuffix(lifecyclev1alpha1.ConditionKubernetesUpgraded, "Upgraded"))
+	PhaseHelmCharts = Phase(strings.TrimSuffix(lifecyclev1alpha1.ConditionHelmChartsUpgraded, "Upgraded"))
+)
+
+// ConditionType returns the condition type string for this phase.
+func (p Phase) ConditionType() string {
+	return string(p) + "Upgraded"
+}
+
+// SkippedStatus retruns a skipped status for the given phase.
+func (p Phase) SkippedStatus() *PhaseStatus {
+	return &PhaseStatus{
+		State:   lifecyclev1alpha1.UpgradeSkipped,
+		Message: fmt.Sprintf("Upgrade for phase '%s' skipped", p),
+	}
+}
+
+// PhaseStatus contains the status and details for an upgrade phase.
+type PhaseStatus struct {
+	State   string
+	Message string
+}
+
+// PhaseError represents an error that occurred during a specific upgrade phase.
+// The underlying Err should contain context-specific details from the reconciler.
+type PhaseError struct {
+	Phase Phase
+	Err   error
+}
+
+func (e *PhaseError) Error() string {
+	return fmt.Sprintf("%s upgrade failed: %v", e.Phase, e.Err)
+}
+
+// Result contains the outcome of the upgrade reconciliation.
+type Result struct {
+	// PhaseStates maps each phase to its current state.
+	PhaseStates map[Phase]*PhaseStatus
+}
+
+// AllComplete returns true if all phases have either succeeded or been skipped.
+func (r *Result) AllComplete() bool {
+	for _, state := range r.PhaseStates {
+		if state.State != lifecyclev1alpha1.UpgradeSucceeded && state.State != lifecyclev1alpha1.UpgradeSkipped {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/upgrade/phase.go
+++ b/internal/upgrade/phase.go
@@ -39,7 +39,7 @@ func (p Phase) ConditionType() string {
 	return string(p) + "Upgraded"
 }
 
-// SkippedStatus retruns a skipped status for the given phase.
+// SkippedStatus returns a skipped status for the given phase.
 func (p Phase) SkippedStatus() *PhaseStatus {
 	return &PhaseStatus{
 		State:   lifecyclev1alpha1.UpgradeSkipped,

--- a/internal/upgrade/pipeline.go
+++ b/internal/upgrade/pipeline.go
@@ -1,0 +1,87 @@
+/*
+Copyright © 2026 SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"context"
+	"fmt"
+
+	lifecyclev1alpha1 "github.com/suse/elemental-lifecycle-manager/api/v1alpha1"
+)
+
+// PhaseHandler defines the interface for handling a single upgrade phase in the pipeline.
+type PhaseHandler interface {
+	// Phase returns the phase this handler is responsible for.
+	Phase() Phase
+	// Reconcile performs the reconciliation for this phase and returns the status.
+	Reconcile(ctx context.Context, config *Config) (*PhaseStatus, error)
+}
+
+// Pipeline executes upgrade phases in sequence, stopping when a phase
+// is not yet complete. This allows the controller to resume from where
+// it left off on the next reconciliation.
+type Pipeline struct {
+	handlers []PhaseHandler
+}
+
+// NewPipeline creates a new pipeline with the given handlers.
+// Handlers are executed in the order they are provided.
+func NewPipeline(handlers ...PhaseHandler) *Pipeline {
+	return &Pipeline{
+		handlers: handlers,
+	}
+}
+
+// Reconcile executes each phase handler in sequence.
+// It stops and returns when:
+// - A phase returns an error (wrapped in PhaseError)
+// - A phase has not yet succeeded (allowing retry on next reconcile)
+// - All phases complete successfully - a completed phase is a phase with a
+// status marked as either 'Succeeded' or 'Skipped'
+func (p *Pipeline) Reconcile(ctx context.Context, config *Config) (*Result, error) {
+	result := &Result{
+		PhaseStates: make(map[Phase]*PhaseStatus),
+	}
+
+	if config == nil {
+		return result, fmt.Errorf("upgrade config is nil")
+	}
+
+	for _, handler := range p.handlers {
+		status, err := handler.Reconcile(ctx, config)
+		if err != nil {
+			return result, &PhaseError{Phase: handler.Phase(), Err: err}
+		}
+		result.PhaseStates[handler.Phase()] = status
+
+		// Stop if phase state is other than succeeded or skipped
+		if status.State != lifecyclev1alpha1.UpgradeSucceeded && status.State != lifecyclev1alpha1.UpgradeSkipped {
+			return result, nil
+		}
+	}
+
+	return result, nil
+}
+
+func (p *Pipeline) Phases() []Phase {
+	phases := make([]Phase, 0, len(p.handlers))
+	for _, h := range p.handlers {
+		phases = append(phases, h.Phase())
+	}
+	return phases
+}


### PR DESCRIPTION
This PR introduces handling for future upgrade handler logic as well as condition updates for the Release resource.

Concepts introduced:
- [upgrade.Phase](https://github.com/ipetrov117/elemental-lifecycle-manager/blob/upgrade_structure_and_conditions/internal/upgrade/phase.go#L28) - This is intended to depict the actual upgrade phase that the pipeline will be going through (e.g. OS, K8s, Helm, etc.).
- [upgrade.Pipeline](https://github.com/ipetrov117/elemental-lifecycle-manager/blob/upgrade_structure_and_conditions/internal/upgrade/pipeline.go) - Introduces `PhaseHandlers` that  are responsible for different upgrade phases. Executes a set of handlers in a specific sequence and reports their status back to the controller.
- [upgrade.Config](https://github.com/ipetrov117/elemental-lifecycle-manager/blob/upgrade_structure_and_conditions/internal/upgrade/config.go#L30) - This is the main instruction set that the pipeline and  future phase handlers will use to understand what changes need to be applied. Is constructed from multiple data points including: parsed release manifest, Release resource, controller specific logic.

Release resource API changes:
- [`spec.disableDrain`](https://github.com/ipetrov117/elemental-lifecycle-manager/blob/upgrade_structure_and_conditions/api/v1alpha1/release_types.go#L68C27-L68C39) - Users can use this property to alter the default controller behaviour when it comes to node drains. By default the controller will look at the cluster nodes and automatically determine whether a drain for a specific node type can be performed (e.g. control-plane, worker, etc.). It then propagates this information to the `upgrade.Config` so that it can be transferred to future phase handlers which will actually schedule the drain itself. By specifying this property, users explicitly instruct the controller to not do any control/worker drains.

> Note: This is the last Release resource API change for the initial LCM logic.

Introduced the following Release `.status.conditions` handling:
- All upgrade components (e.g. Manifest resolution, PhaseHandlers) have their condition status tracked and reported on each reconciliation loop. Effectively allowing for a reliable tracking of the upgrade process.
- When the Release resource is updated all conditions are re-initialised to their initial `Pending` statuses - done to ensure to false information is given during update. 

What will follow after this PR:
- OS reconciliation logic
- K8s reconciliation logic
- Helm reconciliation logic