### PR TITLE
Use the containerd available OS image during OS upgrades

### DIFF
--- a/internal/plan/os.go
+++ b/internal/plan/os.go
@@ -21,6 +21,8 @@ import (
 	"bytes"
 	_ "embed"
 	"fmt"
+	"os"
+	"strconv"
 	"text/template"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -118,10 +120,20 @@ func parseUpgradeScript(osImage string) (string, error) {
 		return "", fmt.Errorf("allocating template for OS upgrade script: %w", err)
 	}
 
+	// By default OS upgrade will be done by using the locally available OS image.
+	// This functionality gives us the option to override that default
+	// and pull the image from its remote instead.
+	fetchRemote := func() bool {
+		value, err := strconv.ParseBool(os.Getenv("E3CTL_FETCH_REMOTE"))
+		return err == nil && value
+	}
+
 	data := struct {
+		FetchRemote    bool
 		OSImageRepo    string
 		OSImageVersion string
 	}{
+		FetchRemote:    fetchRemote(),
 		OSImageRepo:    ref.Context().Name(),
 		OSImageVersion: ref.TagStr(),
 	}

--- a/internal/plan/os_test.go
+++ b/internal/plan/os_test.go
@@ -18,6 +18,9 @@ limitations under the License.
 package plan
 
 import (
+	"os"
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -57,7 +60,7 @@ if [ -n "$CURRENT" ]; then
     fi
 fi
 
-USE_LOCAL_IMAGES=false upgrader "$INCOMING" && chroot /host reboot
+upgrader "$INCOMING" && chroot /host reboot
 `
 	)
 
@@ -88,7 +91,7 @@ USE_LOCAL_IMAGES=false upgrader "$INCOMING" && chroot /host reboot
 	Describe("OSControlPlane", Ordered, func() {
 		var plan *upgradecattlev1.Plan
 
-		BeforeAll(func() {
+		BeforeEach(func() {
 			var err error
 			plan, err = OSControlPlane(releaseName, osImage, osVersion, releaseVersion, drain)
 			Expect(err).ToNot(HaveOccurred())
@@ -143,7 +146,7 @@ USE_LOCAL_IMAGES=false upgrader "$INCOMING" && chroot /host reboot
 	Describe("OSWorker", Ordered, func() {
 		var plan *upgradecattlev1.Plan
 
-		BeforeAll(func() {
+		BeforeEach(func() {
 			var err error
 			plan, err = OSWorker(releaseName, osImage, osVersion, releaseVersion, drain)
 			Expect(err).ToNot(HaveOccurred())
@@ -192,6 +195,28 @@ USE_LOCAL_IMAGES=false upgrader "$INCOMING" && chroot /host reboot
 			Expect(ptr.Deref(plan.Spec.Drain.IgnoreDaemonSets, false)).To(BeTrue())
 			Expect(plan.Spec.Drain.Force).To(BeTrue())
 			Expect(plan.Spec.Drain.Timeout.String()).To(Equal("15m"))
+		})
+	})
+
+	Describe("Upgrade script", func() {
+		It("uses local container images for upgrade", func() {
+			script, err := parseUpgradeScript(osImage)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(script).To(Equal(expectedUpgradeScript))
+			Expect(script).ToNot(ContainSubstring("USE_LOCAL_IMAGES=false upgrader"))
+		})
+
+		It("uses remote container images for upgrade", func() {
+			Expect(os.Setenv("E3CTL_FETCH_REMOTE", "true")).To(Succeed())
+			DeferCleanup(os.Unsetenv, "E3CTL_FETCH_REMOTE")
+
+			old := `upgrader "$INCOMING" && chroot /host reboot`
+			new := `USE_LOCAL_IMAGES=false upgrader "$INCOMING" && chroot /host reboot`
+			expectedRemoteUpgradeScript := strings.Replace(expectedUpgradeScript, old, new, 1)
+
+			script, err := parseUpgradeScript(osImage)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(script).To(Equal(expectedRemoteUpgradeScript))
 		})
 	})
 })

--- a/internal/plan/templates/os-upgrade.sh.tpl
+++ b/internal/plan/templates/os-upgrade.sh.tpl
@@ -21,4 +21,4 @@ if [ -n "$CURRENT" ]; then
     fi
 fi
 
-USE_LOCAL_IMAGES=false upgrader "$INCOMING" && chroot /host reboot
+{{ if .FetchRemote }}USE_LOCAL_IMAGES=false {{ end }}upgrader "$INCOMING" && chroot /host reboot


### PR DESCRIPTION
> **To be merged after [elemental #422](https://github.com/SUSE/elemental/pull/422) has landed and a corresponding OS container image with these changes exists.**

With this PR, LCM schedules OS upgrades to use the locally available OS image by default instead of pulling it from the remote repository for each node upgrade. That way the OS upgrade image will be pulled once (during the initial Pod creation) and after that it will be accessed through containerd's local store.

In addition to that, the suggested changes also introduce a way to override this default behaviour and always fetch the OS image from its remote registry. If the `E3CTL_FETCH_REMOTE=true` environment variable is provided, LCM will disable local image fetch for the underlying `upgrader` script, effectively ensuring that it always pulls from the remote. While unlikely, if something in the default behaviour breaks, this gives us additional flexibility to quickly change the OS image fetch mode to remote.