### PR TITLE
Introduce LCM Helm charts

### DIFF
--- a/charts/elemental-lifecycle-manager-crds/Chart.yaml
+++ b/charts/elemental-lifecycle-manager-crds/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: elemental-lifecycle-manager-crds
+description: Custom Resource Definitions (CRDs) for the Elemental Lifecycle Manager
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/charts/elemental-lifecycle-manager-crds/templates/lifecycle.suse.com_releases.yaml
+++ b/charts/elemental-lifecycle-manager-crds/templates/lifecycle.suse.com_releases.yaml
@@ -1,0 +1,134 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: releases.lifecycle.suse.com
+spec:
+  group: lifecycle.suse.com
+  names:
+    kind: Release
+    listKind: ReleaseList
+    plural: releases
+    singular: release
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Release is the Schema for the releases API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of Release
+            properties:
+              disableDrain:
+                description: DisableDrain specifies whether nodes drain should be
+                  disabled.
+                type: boolean
+              registry:
+                description: Registry specifies an OCI registry to fetch release metadata
+                  from.
+                type: string
+              version:
+                description: Version specifies the target version of the target release.
+                type: string
+            required:
+            - registry
+            - version
+            type: object
+          status:
+            description: status defines the observed state of Release
+            properties:
+              conditions:
+                description: Conditions represent the current state of the release
+                  upgrade.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller. Meant for internal use only.
+                format: int64
+                type: integer
+              version:
+                description: Version is the release version that is currently applied
+                  on the environment.
+                type: string
+            required:
+            - version
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/elemental-lifecycle-manager/Chart.yaml
+++ b/charts/elemental-lifecycle-manager/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: elemental-lifecycle-manager
+description: A Helm chart for the Elemental Lifecycle Manager
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/charts/elemental-lifecycle-manager/templates/_helpers.tpl
+++ b/charts/elemental-lifecycle-manager/templates/_helpers.tpl
@@ -1,0 +1,199 @@
+{{/*
+Expands the name of the chart.
+*/}}
+{{- define "elemental-lifecycle-manager.name" -}}
+{{- default "elemental-lifecycle-manager" .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Expands the fully qualified application name.
+*/}}
+{{- define "elemental-lifecycle-manager.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := include "elemental-lifecycle-manager.name" . -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Expands the name of the controller's service account.
+*/}}
+{{- define "elemental-lifecycle-manager.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "elemental-lifecycle-manager.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Expands the name of the controller's webhook service.
+*/}}
+{{- define "elemental-lifecycle-manager.webhookServiceName" -}}
+{{- default (printf "%s-webhook-service" (include "elemental-lifecycle-manager.fullname" .)) .Values.webhook.service.name -}}
+{{- end -}}
+
+{{/*
+Expands the name of the controller's metrics service.
+*/}}
+{{- define "elemental-lifecycle-manager.metricsServiceName" -}}
+{{- default (printf "%s-metrics-service" (include "elemental-lifecycle-manager.fullname" .)) .Values.metrics.service.name -}}
+{{- end -}}
+
+{{/*
+Expands the name of the ClusterRole that allows clients to read secure metrics.
+*/}}
+{{- define "elemental-lifecycle-manager.metricsReaderRoleName" -}}
+{{- printf "%s-metrics-reader" (include "elemental-lifecycle-manager.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Expands the name of the controller's manager ClusterRole.
+*/}}
+{{- define "elemental-lifecycle-manager.managerRoleName" -}}
+{{- printf "%s-manager-role" (include "elemental-lifecycle-manager.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Expands the name of the controller's manager ClusterRoleBinding.
+*/}}
+{{- define "elemental-lifecycle-manager.managerRoleBindingName" -}}
+{{- printf "%s-manager-rolebinding" (include "elemental-lifecycle-manager.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Returns true when leader election should be enabled for the controller.
+*/}}
+{{- define "elemental-lifecycle-manager.leaderElectionEnabled" -}}
+{{- if gt (int .Values.replicaCount) 1 -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Expands the name of the RBAC role related to leader election.
+*/}}
+{{- define "elemental-lifecycle-manager.leaderRoleName" -}}
+{{- printf "%s-leader-role" (include "elemental-lifecycle-manager.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Expands the name of the RBAC role binding related to leader election.
+*/}}
+{{- define "elemental-lifecycle-manager.leaderRoleBindingName" -}}
+{{- printf "%s-leader-rolebinding" (include "elemental-lifecycle-manager.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Returns true when the chart should create and use the default cert-manager
+webhook certificate instead of an existing user-provided secret.
+*/}}
+{{- define "elemental-lifecycle-manager.useDefaultWebhookCert" -}}
+{{- if and .Values.webhook.enabled .Values.webhook.cert.createDefault -}}
+{{- if .Values.webhook.cert.existingSecret -}}
+{{- fail "webhook.cert.existingSecret must be empty when webhook.cert.createDefault=true" -}}
+{{- end -}}
+{{- if .Values.webhook.cert.caBundle -}}
+{{- fail "webhook.cert.caBundle must be empty when webhook.cert.createDefault=true" -}}
+{{- end -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns true when secure metrics should use a chart-created cert-manager
+certificate instead of an existing user-provided secret.
+*/}}
+{{- define "elemental-lifecycle-manager.useDefaultMetricsCert" -}}
+{{- if and .Values.metrics.enabled .Values.metrics.secure .Values.metrics.cert.createDefault -}}
+{{- if .Values.metrics.cert.existingSecret -}}
+{{- fail "metrics.cert.existingSecret must be empty when metrics.cert.createDefault=true" -}}
+{{- end -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Expands the name of the cert-manager Certificate for the webhook server.
+*/}}
+{{- define "elemental-lifecycle-manager.webhookCertificateName" -}}
+{{- printf "%s-serving-cert" (include "elemental-lifecycle-manager.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Expands the name of the Secret containing the webhook serving certificate.
+*/}}
+{{- define "elemental-lifecycle-manager.webhookCertificateSecretName" -}}
+{{- printf "%s-webhook-server-cert" (include "elemental-lifecycle-manager.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Expands the name of the self-signed cert-manager Issuer.
+*/}}
+{{- define "elemental-lifecycle-manager.certificateIssuerName" -}}
+{{- printf "%s-selfsigned-issuer" (include "elemental-lifecycle-manager.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Expands the name of the cert-manager Certificate for the metrics server.
+*/}}
+{{- define "elemental-lifecycle-manager.metricsCertificateName" -}}
+{{- printf "%s-metrics-certs" (include "elemental-lifecycle-manager.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Expands the name of the Secret containing the metrics serving certificate.
+*/}}
+{{- define "elemental-lifecycle-manager.metricsCertificateSecretName" -}}
+{{- printf "%s-metrics-server-cert" (include "elemental-lifecycle-manager.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Expands the metrics certificate Secret name, requires an existing secret when
+metrics.cert.createDefault is false.
+*/}}
+{{- define "elemental-lifecycle-manager.metricsSecretName" -}}
+{{- if include "elemental-lifecycle-manager.useDefaultMetricsCert" . -}}
+{{- include "elemental-lifecycle-manager.metricsCertificateSecretName" . -}}
+{{- else -}}
+{{- required "metrics.cert.existingSecret is required when metrics.cert.createDefault=false" .Values.metrics.cert.existingSecret -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Expands the webhook certificate Secret name, requires an existing secret when
+webhook.cert.createDefault is false.
+*/}}
+{{- define "elemental-lifecycle-manager.webhookSecretName" -}}
+{{- if include "elemental-lifecycle-manager.useDefaultWebhookCert" . -}}
+{{- include "elemental-lifecycle-manager.webhookCertificateSecretName" . -}}
+{{- else -}}
+{{- required "webhook.cert.existingSecret is required when webhook.cert.createDefault=false" .Values.webhook.cert.existingSecret -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Renders common labels shared by all chart resources.
+*/}}
+{{- define "elemental-lifecycle-manager.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | quote }}
+app.kubernetes.io/name: {{ include "elemental-lifecycle-manager.name" . | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+app.kubernetes.io/part-of: elemental-lifecycle-manager
+{{- end -}}
+
+{{/*
+Renders selector labels shared by the Deployment pod template and Services.
+*/}}
+{{- define "elemental-lifecycle-manager.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "elemental-lifecycle-manager.name" . | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+{{- end -}}

--- a/charts/elemental-lifecycle-manager/templates/certificate.yaml
+++ b/charts/elemental-lifecycle-manager/templates/certificate.yaml
@@ -1,0 +1,49 @@
+{{- if or (include "elemental-lifecycle-manager.useDefaultWebhookCert" .) (include "elemental-lifecycle-manager.useDefaultMetricsCert" .) }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "elemental-lifecycle-manager.certificateIssuerName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "elemental-lifecycle-manager.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+{{- end }}
+{{- if include "elemental-lifecycle-manager.useDefaultWebhookCert" . }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "elemental-lifecycle-manager.webhookCertificateName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "elemental-lifecycle-manager.labels" . | nindent 4 }}
+spec:
+  dnsNames:
+    - {{ include "elemental-lifecycle-manager.webhookServiceName" . }}.{{ .Release.Namespace }}.svc
+    - {{ include "elemental-lifecycle-manager.webhookServiceName" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: {{ include "elemental-lifecycle-manager.certificateIssuerName" . }}
+  secretName: {{ include "elemental-lifecycle-manager.webhookCertificateSecretName" . }}
+{{- end }}
+{{- if include "elemental-lifecycle-manager.useDefaultMetricsCert" . }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "elemental-lifecycle-manager.metricsCertificateName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "elemental-lifecycle-manager.labels" . | nindent 4 }}
+spec:
+  dnsNames:
+    - {{ include "elemental-lifecycle-manager.metricsServiceName" . }}.{{ .Release.Namespace }}.svc
+    - {{ include "elemental-lifecycle-manager.metricsServiceName" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: {{ include "elemental-lifecycle-manager.certificateIssuerName" . }}
+  secretName: {{ include "elemental-lifecycle-manager.metricsCertificateSecretName" . }}
+{{- end }}

--- a/charts/elemental-lifecycle-manager/templates/deployment.yaml
+++ b/charts/elemental-lifecycle-manager/templates/deployment.yaml
@@ -1,0 +1,147 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "elemental-lifecycle-manager.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "elemental-lifecycle-manager.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "elemental-lifecycle-manager.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "elemental-lifecycle-manager.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "elemental-lifecycle-manager.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- $args := list }}
+      {{- if include "elemental-lifecycle-manager.leaderElectionEnabled" . }}
+      {{- $args = append $args "--leader-elect" }}
+      {{- end }}
+      {{- if .Values.webhook.enabled }}
+      {{- $args = append $args "--webhook-cert-path=/tmp/k8s-webhook-server/serving-certs" }}
+      {{- end }}
+      {{- if .Values.metrics.enabled }}
+      {{- $args = append $args "--metrics-bind-address=:8080" }}
+      {{- $args = append $args (printf "--metrics-secure=%t" .Values.metrics.secure) }}
+      {{- if .Values.metrics.secure }}
+      {{- $args = append $args "--metrics-cert-path=/tmp/k8s-metrics-server/metrics-certs" }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.enableHTTP2 }}
+      {{- $args = append $args "--enable-http2" }}
+      {{- end }}
+      {{- with .Values.extraArgs }}
+      {{- $args = concat $args . }}
+      {{- end }}
+      containers:
+        - name: manager
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with $args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if or (not .Values.webhook.enabled) .Values.extraEnv }}
+          env:
+            {{- if not .Values.webhook.enabled }}
+            - name: ENABLE_WEBHOOKS
+              value: "false"
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- if or .Values.metrics.enabled .Values.webhook.enabled }}
+          ports:
+            {{- if .Values.metrics.enabled }}
+            - containerPort: 8080
+              name: metrics
+              protocol: TCP
+            {{- end }}
+            {{- if .Values.webhook.enabled }}
+            - containerPort: {{ .Values.webhook.service.targetPort }}
+              name: webhook-server
+              protocol: TCP
+            {{- end }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: {{ .Values.healthProbe.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.healthProbe.liveness.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: {{ .Values.healthProbe.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.healthProbe.readiness.periodSeconds }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if or .Values.webhook.enabled (and .Values.metrics.enabled .Values.metrics.secure) .Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- if .Values.webhook.enabled }}
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: cert
+              readOnly: true
+            {{- end }}
+            {{- if and .Values.metrics.enabled .Values.metrics.secure }}
+            - mountPath: /tmp/k8s-metrics-server/metrics-certs
+              name: metrics-certs
+              readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if or .Values.webhook.enabled (and .Values.metrics.enabled .Values.metrics.secure) .Values.extraVolumes }}
+      volumes:
+        {{- if .Values.webhook.enabled }}
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: {{ include "elemental-lifecycle-manager.webhookSecretName" . }}
+        {{- end }}
+        {{- if and .Values.metrics.enabled .Values.metrics.secure }}
+        - name: metrics-certs
+          secret:
+            defaultMode: 420
+            secretName: {{ include "elemental-lifecycle-manager.metricsSecretName" . }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      terminationGracePeriodSeconds: 10

--- a/charts/elemental-lifecycle-manager/templates/leader_election_rbac.yaml
+++ b/charts/elemental-lifecycle-manager/templates/leader_election_rbac.yaml
@@ -1,0 +1,57 @@
+{{- if include "elemental-lifecycle-manager.leaderElectionEnabled" . }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "elemental-lifecycle-manager.leaderRoleName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "elemental-lifecycle-manager.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "elemental-lifecycle-manager.leaderRoleBindingName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "elemental-lifecycle-manager.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "elemental-lifecycle-manager.leaderRoleName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "elemental-lifecycle-manager.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/elemental-lifecycle-manager/templates/metrics_service.yaml
+++ b/charts/elemental-lifecycle-manager/templates/metrics_service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "elemental-lifecycle-manager.metricsServiceName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "elemental-lifecycle-manager.labels" . | nindent 4 }}
+  {{- with .Values.metrics.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.metrics.service.type }}
+  ports:
+    - name: {{ ternary "https" "http" .Values.metrics.secure }}
+      port: {{ .Values.metrics.service.port }}
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    {{- include "elemental-lifecycle-manager.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/elemental-lifecycle-manager/templates/rbac.yaml
+++ b/charts/elemental-lifecycle-manager/templates/rbac.yaml
@@ -1,0 +1,138 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "elemental-lifecycle-manager.managerRoleName" . }}
+  labels:
+    {{- include "elemental-lifecycle-manager.labels" . | nindent 4 }}
+rules:
+  - nonResourceURLs:
+      - /version
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - helm.cattle.io
+    resources:
+      - helmcharts
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - lifecycle.suse.com
+    resources:
+      - releases
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - lifecycle.suse.com
+    resources:
+      - releases/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - lifecycle.suse.com
+    resources:
+      - releases/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - upgrade.cattle.io
+    resources:
+      - plans
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  {{- if and .Values.metrics.enabled .Values.metrics.secure }}
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+  {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "elemental-lifecycle-manager.managerRoleBindingName" . }}
+  labels:
+    {{- include "elemental-lifecycle-manager.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "elemental-lifecycle-manager.managerRoleName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "elemental-lifecycle-manager.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- if and .Values.metrics.enabled .Values.metrics.secure }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "elemental-lifecycle-manager.metricsReaderRoleName" . }}
+  labels:
+    {{- include "elemental-lifecycle-manager.labels" . | nindent 4 }}
+rules:
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+{{- end }}

--- a/charts/elemental-lifecycle-manager/templates/serviceaccount.yaml
+++ b/charts/elemental-lifecycle-manager/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "elemental-lifecycle-manager.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "elemental-lifecycle-manager.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- if ne .Values.serviceAccount.automount nil }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}
+{{- end }}

--- a/charts/elemental-lifecycle-manager/templates/validating_webhook_configuration.yaml
+++ b/charts/elemental-lifecycle-manager/templates/validating_webhook_configuration.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.webhook.enabled }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ include "elemental-lifecycle-manager.fullname" . }}-validating-webhook-configuration
+  labels:
+    {{- include "elemental-lifecycle-manager.labels" . | nindent 4 }}
+  {{- if include "elemental-lifecycle-manager.useDefaultWebhookCert" . }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "elemental-lifecycle-manager.webhookCertificateName" . }}
+  {{- end }}
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: {{ include "elemental-lifecycle-manager.webhookServiceName" . }}
+        namespace: {{ .Release.Namespace }}
+        path: /validate-lifecycle-suse-com-v1alpha1-release
+      {{- if and (not (include "elemental-lifecycle-manager.useDefaultWebhookCert" .)) .Values.webhook.cert.caBundle }}
+      caBundle: {{ .Values.webhook.cert.caBundle | quote }}
+      {{- end }}
+    failurePolicy: {{ .Values.webhook.failurePolicy }}
+    name: vrelease.kb.io
+    rules:
+      - apiGroups:
+          - lifecycle.suse.com
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - releases
+    sideEffects: None
+{{- end }}

--- a/charts/elemental-lifecycle-manager/templates/webhook_service.yaml
+++ b/charts/elemental-lifecycle-manager/templates/webhook_service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.webhook.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "elemental-lifecycle-manager.webhookServiceName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "elemental-lifecycle-manager.labels" . | nindent 4 }}
+  {{- with .Values.webhook.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ports:
+    - port: {{ .Values.webhook.service.port }}
+      protocol: TCP
+      targetPort: {{ .Values.webhook.service.targetPort }}
+  selector:
+    {{- include "elemental-lifecycle-manager.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/elemental-lifecycle-manager/values.yaml
+++ b/charts/elemental-lifecycle-manager/values.yaml
@@ -1,0 +1,94 @@
+replicaCount: 1
+
+image:
+  repository: registry.suse.com/beta/uc/elemental-lifecycle-manager
+  pullPolicy: IfNotPresent
+  tag: latest
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  # Automatically mount the service account token into the manager Pod.
+  automount: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+resources: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# Health probe configuration.
+healthProbe:
+  liveness:
+    initialDelaySeconds: 15
+    periodSeconds: 20
+  readiness:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+
+# Metrics endpoint configuration.
+metrics:
+  enabled: false
+  secure: false
+  # Certificate configuration for the metrics server.
+  # Used only when metrics.enabled=true and metrics.secure=true.
+  cert:
+    # When enabled, uses cert-manager to generate a self-signed serving certificate.
+    createDefault: true
+    # Name of an existing Secret containing tls.crt and tls.key to use as the metrics serving certificate.
+    # Used only when cert.createDefault=false.
+    # existingSecret: ""
+  service:
+    name: ""
+    type: ClusterIP
+    port: 8080
+    annotations: {}
+
+# Validation webhook configuration.
+webhook:
+  enabled: true
+  service:
+    name: ""
+    port: 443
+    targetPort: 9443
+    annotations: {}
+  failurePolicy: Fail
+  # Certificate configuration for the webhook.
+  cert:
+    # When enabled, uses cert-manager to generate a self-signed serving certificate.
+    createDefault: true
+    # Name of an existing Secret containing tls.crt and tls.key to use as the webhook serving certificate.
+    # Used only when cert.createDefault=false.
+    # existingSecret: ""
+    # CA bundle used by the API server to verify the webhook serving certificate.
+    # Used only when cert.createDefault=false.
+    # caBundle: ""
+
+# Enables HTTP/2 for the webhook and metrics servers.
+# Disabled by default to reduce exposure to HTTP/2-related vulnerabilities.
+enableHTTP2: false
+
+extraArgs: []
+extraEnv: []
+extraVolumes: []
+extraVolumeMounts: []


### PR DESCRIPTION
This PR allows for the Lifecycle Manager to be deployed as a Helm chart.

The PR introduces two main charts:
- [elemental-lifecycle-manager-crds](https://github.com/ipetrov117/elemental-lifecycle-manager/tree/add_helm_chart/charts/elemental-lifecycle-manager-crds) - ships the `Release` resource CRD outside of the Lifecycle Manager
- [elemental-lifecycle-manager](https://github.com/ipetrov117/elemental-lifecycle-manager/tree/add_helm_chart/charts/elemental-lifecycle-manager) - ships all components related to the Lifecycle Manager (e.g. web hooks, metrics servers, the actual controller, RBAC, certificates, etc.).

What does the `elemental-lifecycle-manager` offer?
1. **Dynamic leader election setup** - leader election is only setup when the `replicaCount > 1`. This ensures we do not ship any unnecessary resources and keep the setup minimal for single replica deployments.
2.   **Dynamic validation webhook setup** - configuration for the validating webhook has been exposed and users can choose whether they want to deploy it. Enabled by default.
3. **Dynamic certificate creation for the validation webhook and metrics server** - both the validation webhook and metrics server (configured with `secure: true`) require TLS certificates. By default, through the `cert.createDefault` configuration, the chart creates a `cert-manager` Issuer and Certificate resources and propagates them to the necessary resources for both the webhook and metrics server. That said, if users are working on environments where having `cert-manager` is not desirable, the chart allows for users to specify a TLS secret (and a `caBundle` for the webhook use-case) containing a custom-user created certificate that will be used for the HTTPS communication.
4. **Dynamic controller metrics exposure** - configuration for the controller's metrics server has been exposed and users can choose whether they wish to enable it and whether they want the `/metrics` endpoint to be exposed over HTTP or HTTPs.
5. **Dynamic controller configuration** - configuration for the controller itself has been exposed. This allows for flexibility in allowing further controller configuration, which can be handy both for users as well as debugging purposes.

> Note: The documentation for the Helm chart will be handled as part of a follow-up PR that introduces enhancement to the whole repo documentation. There we would explicitly state the necessary prerequisites of the charts and the available options and use-cases that it supports.

**Q&As:**
_1. Why are the charts separate?_
Helm does not support upgrading CRDs automatically as part of the Helm chart that actually utilises the CRD itself. This is mainly because Helm cannot determine whether upgrading a CRD will break other things in the cluster. 

Taking a direct quote from the [CRD Handling in Helm 3](https://helm.sh/pt/community/hips/hip-0011/#upgrading-crds) documentation:
> The Helm view on this is that upgrading a CRD is something that an operator should do conscientiously. A manual upgrade of a CRD is safer because it requires the operator to at least be intentional about applying the specific change.

That said having the charts separate, gives the operators the possibility to conscientiously deploy/upgrade the CRDs first and then the chart itself, allowing operators to validate the state and minimise possible friction points.

_2. Why don't we have a default `crds.enabled` property under `elemental-lifecycle-manager`?_
Having such a property opens us up to the same Helm described CRD upgrade problems. For examples users can accidentally enable this property and deploy the controller. Once deployed in this fashion upgrading the CRD becomes harder and possibly more error prone. So keeping things safe, the CRD upgrade/deployment is explicit, avoiding any accidental "shot ourselves in the foot" use-cases.

_3. Why aren't there any chart READMEs?_
Documentation on how the charts are supposed to work and be deployed will be included inside the repository documentation in a follow-up PR. Keep in mind that these charts are intended for "upstream" contributions/easy development testing. The actual per-release Helm charts will be shipped as OCI artefacts. As such it will be beneficial to actually have the chart documentation entered around the repo as opposed to the chart itself.