### PR TITLE
Improve availability reconciliation logic

### DIFF
--- a/internal/upgrade/reconcilers/kubernetes.go
+++ b/internal/upgrade/reconcilers/kubernetes.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	upgradecattlev1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
 	lifecyclev1alpha1 "github.com/suse/elemental-lifecycle-manager/api/v1alpha1"
@@ -45,6 +46,12 @@ type PackagedComponentChartSnapshot struct {
 // PackagedComponentsSnapshot represents a snapshot of the state
 // of all packaged components related to a Kubernetes distribution.
 type PackagedComponentsSnapshot struct {
+	// CreationTime is the time at which the snapshot was created.
+	CreationTime time.Time
+	// SourceKubernetesVersion is the Kubernetes version for which the snapshot was done.
+	SourceKubernetesVersion string
+	// Charts represents the charts package component state related to the given source
+	// Kubernetes version.
 	Charts []*PackagedComponentChartSnapshot
 }
 
@@ -52,10 +59,10 @@ type KubernetesPackagedComponentsHandler interface {
 	// GenerateSnapshot creates a snapshot of the packaged components for a specific Kubernetes distribution.
 	// Returns the packaged components snapshot, or an error otherwise.
 	GenerateSnapshot(ctx context.Context, config *upgrade.Config) (*PackagedComponentsSnapshot, error)
-	// ReconcileAvailability retrieves the currently running packaged components and compares them
-	// with the component states in the given snapshot. If it finds a new or changed component, it
-	// waits for that component to become available.
-	ReconcileAvailability(ctx context.Context, snapshot *PackagedComponentsSnapshot) (*upgrade.PhaseStatus, error)
+	// ReconcileAvailability compares the current packaged components against the given snapshot
+	// and target Kubernetes version. If a component is new or changed, it waits until that
+	// component becomes available.
+	ReconcileAvailability(ctx context.Context, targetVersion string, snapshot *PackagedComponentsSnapshot) (*upgrade.PhaseStatus, error)
 }
 
 // KubernetesReconciler ensures that the Kubernetes distribution of the cluster nodes reflects the desired release state.
@@ -93,7 +100,7 @@ func (r *KubernetesReconciler) Reconcile(ctx context.Context, config *upgrade.Co
 		"version", k8sConfig.Version,
 		"release", config.ReleaseNamespacedName.Name)
 
-	// Before doing any ugrades, generate a snapshot of the current Kubernetes related packaged component states.
+	// Before doing any upgrades, generate a snapshot of the current Kubernetes related packaged component states.
 	snapshot, err := r.packagedComponentsHandler.GenerateSnapshot(ctx, config)
 	if err != nil {
 		return nil, fmt.Errorf("generating Kubernetes packaged components snapshot: %w", err)
@@ -138,7 +145,7 @@ func (r *KubernetesReconciler) Reconcile(ctx context.Context, config *upgrade.Co
 	// Kubernetes distribution to become available. This ensures that both Kubernetes and its related packaged components
 	// are running before the Kubernetes upgrade is marked as 'Succeeded'. It also avoids failures where the controller tries
 	// to upgrade a chart that depends on a core Kubernetes packaged component before that component is ready.
-	if status, err := r.packagedComponentsHandler.ReconcileAvailability(ctx, snapshot); err != nil {
+	if status, err := r.packagedComponentsHandler.ReconcileAvailability(ctx, k8sConfig.Version, snapshot); err != nil {
 		return nil, fmt.Errorf("ensuring Kubernetes packaged components availability: %w", err)
 	} else if status.State != lifecyclev1alpha1.K8sPackagedComponentsAvailable {
 		return status, nil

--- a/internal/upgrade/reconcilers/rke2_core.go
+++ b/internal/upgrade/reconcilers/rke2_core.go
@@ -22,6 +22,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -31,6 +32,7 @@ import (
 	lifecyclev1alpha1 "github.com/suse/elemental-lifecycle-manager/api/v1alpha1"
 	"github.com/suse/elemental-lifecycle-manager/internal/helm"
 	"github.com/suse/elemental-lifecycle-manager/internal/upgrade"
+	"helm.sh/helm/v4/pkg/storage/driver"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -44,6 +46,8 @@ import (
 const (
 	// chartURLAnnotation an annotation that all RKE2 packaged HelmChart components have.
 	chartURLAnnotation = "helm.cattle.io/chart-url"
+	// kubernetesSourceAnnotation represents the annotation for the source Kubernetes version.
+	kubernetesSourceAnnotation = "lifecycle.suse.com/source-kubernetes-version"
 )
 
 // chartSnapshotPair represents a snapshotted HelmChart component and its currently running counterpart.
@@ -91,9 +95,13 @@ func (h *RKE2PackagedComponentsHandler) GenerateSnapshot(ctx context.Context, co
 
 		// Ensure that the blank snapshot was not modified by the Get function.
 		snapshot = h.blankSnapshot(config)
-		if err := h.createSnapshot(ctx, snapshot, config); err != nil {
+		createdSnapshot, err := h.createSnapshot(ctx, snapshot, config)
+		if err != nil {
 			return nil, fmt.Errorf("creating snapshot %s: %w", snapshot.Name, err)
 		}
+
+		snapshot = createdSnapshot
+		return h.parseSnapshot(snapshot)
 	}
 
 	var recreate bool
@@ -113,26 +121,50 @@ func (h *RKE2PackagedComponentsHandler) GenerateSnapshot(ctx context.Context, co
 		}
 
 		snapshot = h.blankSnapshot(config)
-		if err := h.createSnapshot(ctx, snapshot, config); err != nil {
+		createdSnapshot, err := h.createSnapshot(ctx, snapshot, config)
+		if err != nil {
 			return nil, fmt.Errorf("creating snapshot %s: %w", snapshot.Name, err)
 		}
+		snapshot = createdSnapshot
 	}
 
 	return h.parseSnapshot(snapshot)
 }
 
-// ReconcileAvailability uses the provided snapshot to identify changed or newly added RKE2 HelmChart packaged components and wait for them to become available.
-func (h *RKE2PackagedComponentsHandler) ReconcileAvailability(ctx context.Context, snapshot *PackagedComponentsSnapshot) (*upgrade.PhaseStatus, error) {
+// ReconcileAvailability uses the provided snapshot and target version to identify changed or newly added RKE2 HelmChart packaged components and wait for them to become available.
+func (h *RKE2PackagedComponentsHandler) ReconcileAvailability(ctx context.Context, targetVersion string, snapshot *PackagedComponentsSnapshot) (*upgrade.PhaseStatus, error) {
 	snapshotPairs, err := h.findNewOrChangedRKE2PackagedComponents(ctx, snapshot.Charts)
 	if err != nil {
 		return nil, fmt.Errorf("finding new or changed RKE2 packaged components: %w", err)
 	}
 
+	// If no packaged components changed, the snapshot either matches the target Kubernetes version,
+	// or the Helm Controller has not yet updated the packaged component HelmCharts for the new version.
+	if len(snapshotPairs) == 0 {
+		// Mark components as available if the target Kubernetes version matches the one in the snapshot.
+		if targetVersion == snapshot.SourceKubernetesVersion {
+			return &upgrade.PhaseStatus{
+				State:   lifecyclev1alpha1.K8sPackagedComponentsAvailable,
+				Message: "All RKE2 packaged components available",
+			}, nil
+		}
+
+		// Wait for Helm controller to apply the packaged component changes corresponding to the new target version.
+		return &upgrade.PhaseStatus{
+			State: lifecyclev1alpha1.UpgradeInProgress,
+			Message: fmt.Sprintf(
+				"Waiting for RKE2 packaged components change after Kubernetes upgrade from %q to %q",
+				snapshot.SourceKubernetesVersion,
+				targetVersion,
+			),
+		}, nil
+	}
+
 	// For each snapshot pair, wait for the currently active chart to become available.
 	for _, pair := range snapshotPairs {
-		// RKE2 uses the Helm Controller to manage its helm charts, as such it is enough to mark a HelmChart
-		// as available if its Helm Controller created Job has completed.
-		jobComplete, err := h.isHelmChartJobComplete(ctx, pair)
+		// RKE2 uses the Helm Controller to manage its HelmCharts, so a packaged component is
+		// considered available once the Helm Controller Job completed after the snapshot was created.
+		jobComplete, err := h.isHelmChartJobComplete(ctx, pair, snapshot.CreationTime)
 		if err != nil {
 			return nil, fmt.Errorf("validating job for RKE2 packaged component %q: %w", pair.Chart.Name, err)
 		}
@@ -160,21 +192,41 @@ func (h *RKE2PackagedComponentsHandler) blankSnapshot(config *upgrade.Config) *c
 				lifecyclev1alpha1.ReleaseNameLabel:    config.ReleaseNamespacedName.Name,
 				lifecyclev1alpha1.ReleaseVersionLabel: lifecyclev1alpha1.SanitizeVersion(config.ReleaseVersion),
 			},
+			Annotations: map[string]string{},
 		},
 	}
 }
 
-func (h *RKE2PackagedComponentsHandler) createSnapshot(ctx context.Context, snapshot *corev1.ConfigMap, config *upgrade.Config) error {
-	if err := h.populateSnapshot(ctx, snapshot); err != nil {
-		return fmt.Errorf("populating RKE2 packaged components snapshot: %w", err)
+// createSnapshot creates a snapshot from the given snapshot template and returns the created Kubernetes resource, or an error otherwise.
+func (h *RKE2PackagedComponentsHandler) createSnapshot(ctx context.Context, snapshotTpl *corev1.ConfigMap, config *upgrade.Config) (*corev1.ConfigMap, error) {
+	nodes := &corev1.NodeList{}
+	// RKE2 keeps all nodes on the same Kubernetes version, so one node is enough
+	// to determine the cluster version for the snapshot.
+	if err := h.List(ctx, nodes, client.Limit(1)); err != nil {
+		return nil, fmt.Errorf("listing node: %w", err)
+	}
+
+	snapshotTpl.Annotations[kubernetesSourceAnnotation] = nodes.Items[0].Status.NodeInfo.KubeletVersion
+
+	if err := h.populateSnapshot(ctx, snapshotTpl); err != nil {
+		return nil, fmt.Errorf("populating RKE2 packaged components snapshot: %w", err)
 	}
 
 	log.FromContext(ctx).Info("Generating RKE2 packaged components snapshot",
-		"name", snapshot.Name,
-		"namespace", snapshot.Namespace,
+		"name", snapshotTpl.Name,
+		"namespace", snapshotTpl.Namespace,
 		"owner", config.ReleaseNamespacedName.Name,
 	)
-	return h.Create(ctx, snapshot)
+	if err := h.Create(ctx, snapshotTpl); err != nil {
+		return nil, fmt.Errorf("creating snapshot %s: %w", snapshotTpl.Name, err)
+	}
+
+	created := &corev1.ConfigMap{}
+	if err := h.Get(ctx, client.ObjectKeyFromObject(snapshotTpl), created); err != nil {
+		return nil, fmt.Errorf("retrieving snapshot %s: %w", snapshotTpl.Name, err)
+	}
+
+	return created, nil
 }
 
 // populateSnapshot locates the currently running RKE2 packaged components, marshals them and stores them in the
@@ -231,7 +283,11 @@ func (h *RKE2PackagedComponentsHandler) createHelmChartSnapshot(chart helmv1.Hel
 }
 
 func (h *RKE2PackagedComponentsHandler) parseSnapshot(snapshot *corev1.ConfigMap) (*PackagedComponentsSnapshot, error) {
-	parsedSnapshot := &PackagedComponentsSnapshot{}
+	parsedSnapshot := &PackagedComponentsSnapshot{
+		CreationTime:            snapshot.CreationTimestamp.UTC(),
+		SourceKubernetesVersion: snapshot.Annotations[kubernetesSourceAnnotation],
+	}
+
 	for name, data := range snapshot.Data {
 		parsedChartSnapshot := &PackagedComponentChartSnapshot{}
 		if err := json.Unmarshal([]byte(data), parsedChartSnapshot); err != nil {
@@ -310,7 +366,9 @@ func (h *RKE2PackagedComponentsHandler) chartStateChanged(chart *helmv1.HelmChar
 		chart.Annotations[chartURLAnnotation] != chartSnapshot.ChartURL
 }
 
-func (h *RKE2PackagedComponentsHandler) isHelmChartJobComplete(ctx context.Context, pair *chartSnapshotPair) (bool, error) {
+// isHelmChartJobComplete returns true when the HelmChart's current Job completed after the snapshot creation time.
+// If the Job is missing, the function falls back to the Helm release object.
+func (h *RKE2PackagedComponentsHandler) isHelmChartJobComplete(ctx context.Context, pair *chartSnapshotPair, snapshotCreation time.Time) (bool, error) {
 	chart := pair.Chart
 
 	// Missing Job name in chart status means that the Helm Controller
@@ -324,7 +382,8 @@ func (h *RKE2PackagedComponentsHandler) isHelmChartJobComplete(ctx context.Conte
 		Name:      chart.Status.JobName,
 		Namespace: chart.Namespace,
 	}, job); err != nil {
-		// Job might be cleaned up after completion, check actual helm release version
+		// Job might be cleaned up after completion, or might not yet be created.
+		// Validate which is the case, by looking at the actual Helm release.
 		if apierrors.IsNotFound(err) {
 			return h.hasHelmReleaseAdvancedPastSnapshot(pair)
 		}
@@ -341,12 +400,24 @@ func (h *RKE2PackagedComponentsHandler) isHelmChartJobComplete(ctx context.Conte
 		return false, nil
 	}
 
-	return h.hasHelmReleaseAdvancedPastSnapshot(pair)
+	// Safeguard for the corner case, where the Job is marked as 'Completed', but
+	// the timestamp is not yet populated.
+	if job.Status.CompletionTime == nil || job.Status.CompletionTime.IsZero() {
+		return false, nil
+	}
+
+	// Ensure the Job completed after the recorded snapshot creation time. Helm Controller can delay
+	// creating a new HelmChart Job, so this prevents treating a stale Job as current.
+	return job.Status.CompletionTime.After(snapshotCreation), nil
 }
 
 func (h *RKE2PackagedComponentsHandler) hasHelmReleaseAdvancedPastSnapshot(pair *chartSnapshotPair) (bool, error) {
 	release, err := h.helmClient.RetrieveRelease(pair.Chart.Name)
 	if err != nil {
+		// A missing Helm release indicates that this is a new component not yet handled by the Helm Controller.
+		if errors.Is(err, driver.ErrReleaseNotFound) {
+			return false, nil
+		}
 		return false, fmt.Errorf("retrieving RKE2 packaged component Helm release %q: %w", pair.Chart.Name, err)
 	}
 


### PR DESCRIPTION
**Problem:**
On some Kubernetes upgrade runs, the  RKE2 packaged components [availability check](https://github.com/SUSE/elemental-lifecycle-manager/blob/main/internal/upgrade/reconcilers/rke2_core.go#L125) wrongfully reports the components as available, while in reality the `Helm Controller` has not yet created the new HelmChart upgrade/install Jobs. This leads to the `KubernetesUpgraded` Phase to be wrongfully marked as `Succeeded` which in turn moves the LCM to the Helm upgrade logic, while the RKE2 packaged components are not yet available.

**Reason:**
Currently, the RKE2 packaged components availability check only determines whether the active components differ from the last recorded snapshot. It does not consider whether the Kubernetes version has changed since that snapshot.

As a result, the check is not tied to the Kubernetes upgrade flow and does not wait for the `Helm Controller` to react to the new Kubernetes version. This creates a race condition where immediately after Kubernetes is upgraded, both the availability check and the `Helm Controller` are triggered, but the availability check may run before the `Helm Controller` has started upgrading the packaged components, causing the wrongful availability report.

**Solution:**
To avoid this race condition, the [PackagedComponentsSnapshot](https://github.com/SUSE/elemental-lifecycle-manager/blob/main/internal/upgrade/reconcilers/kubernetes.go#L47) has been extended to also include:
1. The Kubernetes version that the snapshotted components relate to
2. The creation time of the actual snapshot

The above points in combination with passing the [target Kubernetes version ](https://github.com/ipetrov117/elemental-lifecycle-manager/blob/fix_race_condition/internal/upgrade/reconcilers/kubernetes.go#L65) to the availability check enables the logic to be able to correctly determine whether the components that it reconciles are actually available or the `Helm Controller` has not yet updated them.

With these changes the following use-case workflows are supported:

| Use Case | Availability Report | Notes |
|----------|----------|----------|
| Snapshot and target Kubernetes versions equal; packaged components changed  | `InProgress` | A very rare case that involves an admin manually making changes over a packaged component. Since the components have changed after the snapshot has been taken, component availability needs to be validated.  |
| Snapshot and target Kubernetes versions differ; no changed components detected; `Helm Controller` not yet scheduled a component update  | `InProgress`  | While no component checks have been detected, a change in the Kubernetes version always merits a change to at least one packaged component. Hence the availability check determines that the `Helm Controller` has not yet scheduled the component updates and marks the process as `InProgress`.  |
| Snapshot and target Kubernetes versions differ; packaged components changed; `Helm Controller` update in progress | `InProgress`  | Availability check reconciles each changed component and looks at its Job and whether it has completed after the snapshot creation. Since `Helm Controller` update is in progress, this means that not all packaged component Jobs have completed, hence marking `InProgress`  |
| Snapshot and target Kubernetes versions differ; packaged components changed; `Helm Controller` update finished  | `PackagedComponentsAvailable`  | Since the `Helm Controller` packaged components update has completed, this means that all packaged component Jobs have completed. The availability check reconciles each changed packaged component and validates that each Job is completed and more importantly has completed **after**  the initial snapshot was created. This ensures that after the snapshot all components that have changed have actually been updated by the `Helm Controller`. |
| Snapshot and target Kubernetes versions equal; no changed packaged components  |`PackagedComponentsAvailable`  |  No changed components + equal target and snapshot Kubernetes versions indicates that the state of the snapshotted components has not changed between the snapshot and the time the availability is validated. Hence components are reported as available.  |