### PR TITLE
Move commonly used vars under constants

### DIFF
--- a/internal/plan/os.go
+++ b/internal/plan/os.go
@@ -34,6 +34,7 @@ import (
 const (
 	osControlPlaneBaseName = "elemental-os-control-plane"
 	osWorkerBaseName       = "elemental-os-worker"
+	osUpgradeShell         = "/bin/sh"
 )
 
 //go:embed templates/os-upgrade.sh.tpl
@@ -73,7 +74,7 @@ func OSControlPlane(releaseName, osImage, osVersion, releaseVersion string, drai
 	}
 	p.Spec.Upgrade = &upgradecattlev1.ContainerSpec{
 		Image:   osImage,
-		Command: []string{"/bin/sh", "-c"},
+		Command: []string{osUpgradeShell, "-c"},
 		Args:    []string{script},
 	}
 	return p, nil
@@ -103,7 +104,7 @@ func OSWorker(releaseName, osImage, osVersion, releaseVersion string, drain bool
 	}
 	p.Spec.Upgrade = &upgradecattlev1.ContainerSpec{
 		Image:   osImage,
-		Command: []string{"/bin/sh", "-c"},
+		Command: []string{osUpgradeShell, "-c"},
 		Args:    []string{script},
 	}
 	return p, nil

--- a/internal/plan/os_test.go
+++ b/internal/plan/os_test.go
@@ -130,7 +130,7 @@ upgrader "$INCOMING" && chroot /host reboot
 		It("configures upgrade container", func() {
 			Expect(plan.Spec.Upgrade).ToNot(BeNil())
 			Expect(plan.Spec.Upgrade.Image).To(Equal(osImage))
-			Expect(plan.Spec.Upgrade.Command).To(Equal([]string{"/bin/sh", "-c"}))
+			Expect(plan.Spec.Upgrade.Command).To(Equal([]string{osUpgradeShell, "-c"}))
 			Expect(plan.Spec.Upgrade.Args).To(Equal([]string{expectedUpgradeScript}))
 		})
 
@@ -185,7 +185,7 @@ upgrader "$INCOMING" && chroot /host reboot
 		It("configures upgrade container", func() {
 			Expect(plan.Spec.Upgrade).ToNot(BeNil())
 			Expect(plan.Spec.Upgrade.Image).To(Equal(osImage))
-			Expect(plan.Spec.Upgrade.Command).To(Equal([]string{"/bin/sh", "-c"}))
+			Expect(plan.Spec.Upgrade.Command).To(Equal([]string{osUpgradeShell, "-c"}))
 			Expect(plan.Spec.Upgrade.Args).To(Equal([]string{expectedUpgradeScript}))
 		})
 

--- a/internal/webhook/v1alpha1/release_webhook_test.go
+++ b/internal/webhook/v1alpha1/release_webhook_test.go
@@ -29,13 +29,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	testNamespace   = "default"
+	testRegistry    = "registry.example.com"
+	testReleaseName = "release"
+)
+
 var _ = Describe("Release Webhook", func() {
 	Context("When creating Release under Validating Webhook", Ordered, func() {
 		It("Should be denied if registry is not specified", func() {
 			release := &lifecyclev1alpha1.Release{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "release",
-					Namespace: "default",
+					Name:      testReleaseName,
+					Namespace: testNamespace,
 				},
 			}
 
@@ -47,11 +53,11 @@ var _ = Describe("Release Webhook", func() {
 		It("Should be denied if release version is not specified", func() {
 			release := &lifecyclev1alpha1.Release{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "release",
-					Namespace: "default",
+					Name:      testReleaseName,
+					Namespace: testNamespace,
 				},
 				Spec: lifecyclev1alpha1.ReleaseSpec{
-					Registry: "registry.example.com",
+					Registry: testRegistry,
 				},
 			}
 
@@ -63,11 +69,11 @@ var _ = Describe("Release Webhook", func() {
 		It("Should be denied if release version is not in semantic format", func() {
 			release := &lifecyclev1alpha1.Release{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "release",
-					Namespace: "default",
+					Name:      testReleaseName,
+					Namespace: testNamespace,
 				},
 				Spec: lifecyclev1alpha1.ReleaseSpec{
-					Registry: "registry.example.com",
+					Registry: testRegistry,
 					Version:  "v1",
 				},
 			}
@@ -80,11 +86,11 @@ var _ = Describe("Release Webhook", func() {
 		It("Should admit if all required fields are provided", func() {
 			release := &lifecyclev1alpha1.Release{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "release",
-					Namespace: "default",
+					Name:      testReleaseName,
+					Namespace: testNamespace,
 				},
 				Spec: lifecyclev1alpha1.ReleaseSpec{
-					Registry: "registry.example.com",
+					Registry: testRegistry,
 					Version:  "0.5.0",
 				},
 			}
@@ -96,10 +102,10 @@ var _ = Describe("Release Webhook", func() {
 			release := &lifecyclev1alpha1.Release{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "release2",
-					Namespace: "default",
+					Namespace: testNamespace,
 				},
 				Spec: lifecyclev1alpha1.ReleaseSpec{
-					Registry: "registry.example.com",
+					Registry: testRegistry,
 					Version:  "0.5.0",
 				},
 			}
@@ -115,7 +121,7 @@ var _ = Describe("Release Webhook", func() {
 
 		BeforeEach(func() {
 			release = &lifecyclev1alpha1.Release{}
-			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: "release", Namespace: "default"}, release)).To(Succeed())
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: testReleaseName, Namespace: testNamespace}, release)).To(Succeed())
 		})
 
 		It("Should be denied if release registry is not specified", func() {
@@ -198,11 +204,11 @@ var _ = Describe("Release Webhook", func() {
 	Context("When deleting Release under Validating Webhook", Ordered, func() {
 		release := &lifecyclev1alpha1.Release{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "release",
-				Namespace: "default",
+				Name:      testReleaseName,
+				Namespace: testNamespace,
 			},
 			Spec: lifecyclev1alpha1.ReleaseSpec{
-				Registry: "registry.example.com",
+				Registry: testRegistry,
 				Version:  "1.0.0",
 			},
 		}


### PR DESCRIPTION
Fixes the `goconst` linter errors seen in #21 and #20.