### PR TITLE
Retrieve LCM image tag from .Chart.appVersion by default

### DIFF
--- a/charts/elemental-lifecycle-manager/templates/deployment.yaml
+++ b/charts/elemental-lifecycle-manager/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
       {{- end }}
       containers:
         - name: manager
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with $args }}
           args:

--- a/charts/elemental-lifecycle-manager/values.yaml
+++ b/charts/elemental-lifecycle-manager/values.yaml
@@ -3,7 +3,8 @@ replicaCount: 1
 image:
   repository: registry.suse.com/beta/uc/elemental-lifecycle-manager
   pullPolicy: IfNotPresent
-  tag: latest
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
This better aligns `values.yaml` with `Chart.yaml`.

The chart now defaults the manager image tag to `Chart.yaml`'s `appVersion` when `image.tag` is not set. This ensures the chart deploys the application version declared by the chart by default, while still allowing users to override the image tag when needed.
