### PR TITLE
Allow for LCM to upgrade Helm charts with OCI references

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ LCM facilitates additional component upgrades by using the [Helm Controller](htt
 RKE2 clusters have this controller built-in. It is enabled by default and users of LCM should ensure that it is not manually
 disabled via the respective CLI argument or config file parameter.
 
+## Limitations
+
+-  Issue: [#28](https://github.com/SUSE/elemental-lifecycle-manager/issues/28). Private Helm charts can be upgraded only when they are managed by the Helm Controller. If the chart was deployed directly through Helm (e.g. `helm install`), first create a [`HelmChart`](https://github.com/k3s-io/helm-controller/blob/master/doc/helmchart.md#HelmChart) resource with the required repository credentials before scheduling the upgrade through LCM.
+
+-  Issue: [#28](https://github.com/SUSE/elemental-lifecycle-manager/issues/28). Helm chart upgrades that switch the chart from a public to a private reference are not handled automatically. Before scheduling the upgrade, configure the chart's corresponding [`HelmChart`](https://github.com/k3s-io/helm-controller/blob/master/doc/helmchart.md#HelmChart) resoruce to include the required credentials for the private reference.
+
 ## Quickstart
 
 ### Install Elemental Lifecycle Manager

--- a/internal/upgrade/reconcilers/helm.go
+++ b/internal/upgrade/reconcilers/helm.go
@@ -22,7 +22,9 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"net/url"
 	"slices"
+	"strings"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -261,7 +263,10 @@ func (r *HelmReconciler) createHelmChartFromRelease(ctx context.Context, chart *
 
 // updateHelmChart updates an existing HelmChart CR to trigger an upgrade.
 func (r *HelmReconciler) updateHelmChart(ctx context.Context, chart *api.HelmChart, existing *helmv1.HelmChart) error {
-	repoURL := r.resolveRepositoryURL(chart)
+	repoURL, err := r.resolveRepositoryURL(chart)
+	if err != nil {
+		return fmt.Errorf("parsing repository URL for chart %q: %w", chart.Name, err)
+	}
 
 	// Ensure labels are set for Release tracking
 	if existing.Labels == nil {
@@ -270,9 +275,16 @@ func (r *HelmReconciler) updateHelmChart(ctx context.Context, chart *api.HelmCha
 	existing.Labels[lifecyclev1alpha1.ReleaseNameLabel] = r.releaseName
 	existing.Labels[lifecyclev1alpha1.ReleaseVersionLabel] = lifecyclev1alpha1.SanitizeVersion(r.releaseVersion)
 
-	existing.Spec.Chart = chart.Chart
 	existing.Spec.Version = chart.Version
-	existing.Spec.Repo = repoURL
+	if repoURL.Scheme == "oci" {
+		// HelmChart's referencing OCI images expect the full OCI reference to be
+		// specified under Spec.Chart and for Spec.Repo to be empty.
+		existing.Spec.Chart = fmt.Sprintf("%s/%s", strings.TrimSuffix(repoURL.String(), "/"), chart.Chart)
+		existing.Spec.Repo = ""
+	} else {
+		existing.Spec.Chart = chart.Chart
+		existing.Spec.Repo = repoURL.String()
+	}
 
 	// Merge existing values with new manifest values
 	if len(chart.Values) > 0 {
@@ -297,7 +309,10 @@ func (r *HelmReconciler) updateHelmChart(ctx context.Context, chart *api.HelmCha
 // buildHelmChart creates a HelmChart resource from the manifest chart definition.
 func (r *HelmReconciler) buildHelmChart(chart *api.HelmChart, targetNamespace string) (*helmv1.HelmChart, error) {
 	name := chart.GetName()
-	repoURL := r.resolveRepositoryURL(chart)
+	repoURL, err := r.resolveRepositoryURL(chart)
+	if err != nil {
+		return nil, fmt.Errorf("parsing repository URL for chart %q: %w", chart.Name, err)
+	}
 
 	if targetNamespace == "" {
 		targetNamespace = chart.Namespace
@@ -319,12 +334,20 @@ func (r *HelmReconciler) buildHelmChart(chart *api.HelmChart, targetNamespace st
 			},
 		},
 		Spec: helmv1.HelmChartSpec{
-			Chart:           chart.Chart,
 			Version:         chart.Version,
-			Repo:            repoURL,
 			TargetNamespace: targetNamespace,
 			BackOffLimit:    &backoffLimit,
 		},
+	}
+
+	if repoURL.Scheme == "oci" {
+		// HelmChart's referencing OCI images expect the full OCI reference to be
+		// specified under Spec.Chart and for Spec.Repo to be empty.
+		helmChart.Spec.Chart = fmt.Sprintf("%s/%s", strings.TrimSuffix(repoURL.String(), "/"), chart.Chart)
+		helmChart.Spec.Repo = ""
+	} else {
+		helmChart.Spec.Chart = chart.Chart
+		helmChart.Spec.Repo = repoURL.String()
 	}
 
 	if len(chart.Values) > 0 {
@@ -338,20 +361,14 @@ func (r *HelmReconciler) buildHelmChart(chart *api.HelmChart, targetNamespace st
 	return helmChart, nil
 }
 
-// resolveRepositoryURL resolves the repository URL for a chart.
-func (r *HelmReconciler) resolveRepositoryURL(chart *api.HelmChart) string {
-	repoName := chart.GetRepositoryName()
-	if repoName != "" {
-		if url, ok := r.repositoryURLs[repoName]; ok {
-			return url
-		}
+// resolveRepositoryURL resolves and parses the repository URL for a chart.
+func (r *HelmReconciler) resolveRepositoryURL(chart *api.HelmChart) (*url.URL, error) {
+	repositoryURL := chart.Repository
+	if resolvedURL, ok := r.repositoryURLs[repositoryURL]; ok {
+		repositoryURL = resolvedURL
 	}
 
-	if chart.Repository != "" {
-		return chart.Repository
-	}
-
-	return ""
+	return url.Parse(repositoryURL)
 }
 
 // evaluateHelmChartJobStatus checks the status of the Helm upgrade job.


### PR DESCRIPTION
Right now LCM supports release manifests that define an OCI Helm chart in the following manner:

```yaml
components:
  helm:
    charts:
      - chart: "oci://registry.example.com/foo/bar-chart"
        version: "0.0.0"
        namespace: "bar-system"
```

However, the elemental stack only [supports](https://github.com/SUSE/elemental/blob/main/internal/config/helm.go#L242-L245) release manifests with OCI Helm charts defined in the following way:

```yaml
components:
  helm:
    charts:
      - chart: "bar-chart"
        version: "0.0.0"
        namespace: "bar-system"
        repository: "oci-repo"
  repositories:
      - name: "oci-repo"
        url: "oci://registry.example.com/foo"
```

So there is a disconnect with how LCM and respectively elemental expect an OCI chart to be defined in a release manifest.

In order to keep the convention introduced by the elemental stack intact, this PR enhances LCM to be able to parse the following OCI Chart <-> release manifest definition use-cases:

- Repository URL directly defined within the `components.helm.charts[*].repository` field.
- Full chart OCI url defined under `components.helm.charts[*].chart` field, where `components.helm.charts[*].repository` is empty.
- OCI repository defined under `components.helm.repositories[*]` and referenced under `components.helm.charts[*].repository` - elemental stack supported use-case.

This gives LCM the flexibility to support all available ways that a OCI Helm chart can be defined, while also not breaking existing logic and being compatible with how the elemental stack expects a release manifest to be defined. Effectively ensuring that the same release manifest structure can be used both for initial image customisations and environment upgrades.

The suggested logic supports the following upgrade use-cases:

|Use Case | Supported | Description |
|---|---|---|
| Public OCI Helm chart deployed via `helm install`; no `HelmChart` resource | Yes | LCM creates a `HelmChart` resource with the `spec.chart` equal to the full OCI chart reference and an empty `spec.repo` field. |
| Public HTTS Helm chart deployed via `helm install`; no `HelmChart` resource | Yes | LCM creates a `HelmChart` resource with the `spec.repo` field pointing to the chart repository and the `spec.chart` field containing only the chart. |
| Public OCI Helm chart deployed through a `HelmChart` resource | Yes | LCM updates the existing `HelmChart` resource. |
| Public HTTPS Helm chart deployed through a `HelmChart` resource | Yes | LCM updates the existing `HelmChart` resource. |
| Private OCI Helm chart deployed through a `HelmChart` resource | Yes | LCM updates the existing `HelmChart` resource. LCM does not touch any `HelmChart` defined credentials. |
| Private HTTPS Helm chart deployed through a `HelmChart` resource | Yes | LCM updates the existing `HelmChart` resource. LCM does not touch any `HelmChart` defined credentials. |
| Private OCI Helm chart deployed via `helm install`; no `HelmChart` resource | No | As of this moment LCM does not support updating credentials of existing charts. Since the chart is deployed via `helm install`, LCM has no way to retrieve any of the chart credentials and thus has not way to setup a `HelmChart` resource with the necessary credentials. **This will be fixed in the post-0.6 versions.** |
| Private HTTPS Helm chart deployed via `helm install`; no `HelmChart` resource | No | As of this moment LCM does not support updating credentials of existing charts. Since the chart is deployed via `helm install`, LCM has no way to retrieve any of the chart credentials and thus has not way to setup a `HelmChart` resource with the necessary credentials. **This will be fixed in the post-0.6 versions.**|
| Public `HelmChart` resource is updated to point to a private reference | No | As of this moment LCM does not have a notion of chart credentials. As such, it cannot reliably update the public chart to point to a private reference without manual user intervention. |

The unsupported use-cases, would require manual user intervention to allow for an upgrade which is described in the new `Limitations` section that has been added to the project.

**How does LCM handle private Helm chart upgrades?**

Since LCM is not yet capable of updating any chart credentials, it relies on the `HelmChart` resources to be configured with the correct repository credentials, while it only handles the actual version update. This is a reasonable compromise, as any `HelmChart` resource that does not have the correct credentials will fail during installation.

I refrained from introducing credential handling logic in LCM for the short term as it would involve new API changes to the `Release` resource, which I am hesitant to introduce based on our tight timeline. The suggested approach is not perfect, but it is capable enough to handle much of the use-cases that we need, while also documenting use-cases that are not yet supported.