### PR TITLE
[backport] Check type for circular dependency processing

### DIFF
--- a/internal/upgrade/reconcilers/helm.go
+++ b/internal/upgrade/reconcilers/helm.go
@@ -168,8 +168,10 @@ func sortChartsByDependencies(charts []*api.HelmChart) ([]*api.HelmChart, error)
 
 		// Visit dependencies first
 		for _, dep := range chart.DependsOn {
-			if err := visit(dep.Name); err != nil {
-				return err
+			if dep.Type == api.DependencyTypeHelm {
+				if err := visit(dep.Name); err != nil {
+					return err
+				}
 			}
 		}
 

--- a/internal/upgrade/reconcilers/helm_test.go
+++ b/internal/upgrade/reconcilers/helm_test.go
@@ -321,8 +321,8 @@ var _ = Describe("HelmReconciler", func() {
 
 	Describe("dependency ordering (tested indirectly)", func() {
 		It("should detect circular dependencies", func() {
-			chart1 := testutil.NewTestHelmChart("chart1", "1.0.0", testutil.WithDependencies([]string{"chart2"}))
-			chart2 := testutil.NewTestHelmChart("chart2", "1.0.0", testutil.WithDependencies([]string{"chart1"}))
+			chart1 := testutil.NewTestHelmChart("chart1", "1.0.0", testutil.WithDependencies([]api.HelmChartDependency{{Name: "chart2", Type: api.DependencyTypeHelm}}))
+			chart2 := testutil.NewTestHelmChart("chart2", "1.0.0", testutil.WithDependencies([]api.HelmChartDependency{{Name: "chart1", Type: api.DependencyTypeHelm}}))
 			config = testutil.NewTestConfig(testutil.WithHelmCharts([]*api.HelmChart{chart1, chart2}))
 
 			// Mock both charts as installed
@@ -341,11 +341,35 @@ var _ = Describe("HelmReconciler", func() {
 			Expect(err.Error()).To(ContainSubstring("circular dependency"))
 			Expect(status).NotTo(BeNil())
 			Expect(status.State).To(Equal(lifecyclev1alpha1.UpgradeFailed))
+
+		})
+
+		It("should not error when sysext dependency has same name as helm chart", func() {
+			chart1 := testutil.NewTestHelmChart("chart1", "1.0.0", testutil.WithDependencies([]api.HelmChartDependency{{Name: "chart1", Type: api.DependencyTypeExtension}}))
+			chart2 := testutil.NewTestHelmChart("chart2", "1.0.0", testutil.WithDependencies([]api.HelmChartDependency{{Name: "chart1", Type: api.DependencyTypeHelm}}))
+			config = testutil.NewTestConfig(testutil.WithHelmCharts([]*api.HelmChart{chart1, chart2}))
+
+			// Mock both charts as installed
+			mockHelm.RetrieveReleaseFn = func(name string) (*helm.ReleaseInfo, error) {
+				return &helm.ReleaseInfo{
+					ChartVersion: testChartVersion,
+					Namespace:    testNamespace,
+					Config:       map[string]any{},
+					Revisions:    1,
+				}, nil
+			}
+
+			status, err := reconciler.Reconcile(ctx, config)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(status).ToNot(BeNil())
+			Expect(status.Message).To(Equal("All 2 Helm charts upgraded successfully (0 skipped)"))
+			Expect(status.State).To(Equal(lifecyclev1alpha1.UpgradeSucceeded))
 		})
 
 		It("should process dependencies before dependents", func() {
 			dep := testutil.NewTestHelmChart("dependency", "1.0.0")
-			parent := testutil.NewTestHelmChart("parent", "2.0.0", testutil.WithDependencies([]string{"dependency"}))
+			parent := testutil.NewTestHelmChart("parent", "2.0.0", testutil.WithDependencies([]api.HelmChartDependency{{Name: "dependency", Type: api.DependencyTypeHelm}}))
 			config = testutil.NewTestConfig(testutil.WithHelmCharts([]*api.HelmChart{parent, dep}))
 
 			processedCharts := []string{}

--- a/internal/upgrade/reconcilers/testutil/builders.go
+++ b/internal/upgrade/reconcilers/testutil/builders.go
@@ -85,12 +85,13 @@ func WithHelmCharts(charts []*api.HelmChart) ConfigOpts {
 
 type HelmChartOpts func(h *api.HelmChart)
 
-func WithDependencies(dependencies []string) HelmChartOpts {
+func WithDependencies(dependencies []api.HelmChartDependency) HelmChartOpts {
 	return func(h *api.HelmChart) {
 		h.DependsOn = make([]api.HelmChartDependency, len(dependencies))
 		for i, dep := range dependencies {
 			h.DependsOn[i] = api.HelmChartDependency{
-				Name: dep,
+				Name: dep.Name,
+				Type: dep.Type,
 			}
 		}
 	}


### PR DESCRIPTION
For a solution manifest file like one at
<https://github.com/SUSE/elemental/blob/e80bebaa4fc58db23c470c817ed3064ddc2176c8/examples/elemental/customize/single-node/suse-solution-manifest.yaml> where a chart named 'longhorn' has a dependency on a sysext of the same name, LCM's `sortChartsByDependencies` function treated both as same on the basis of name. This caused the Helm charts upgrade of LCM to fail. This PR adds a check to ensure that only a dependency of type Chart is checked for such circular dependencies.


Update internal/upgrade/reconcilers/helm_test.go