### PR TITLE
Ensure existence of secret keys for helm values

### DIFF
--- a/internal/webhook/v1alpha1/release_webhook.go
+++ b/internal/webhook/v1alpha1/release_webhook.go
@@ -33,6 +33,7 @@ import (
 
 	lifecyclev1alpha1 "github.com/suse/elemental-lifecycle-manager/api/v1alpha1"
 	"github.com/suse/elemental-lifecycle-manager/internal/upgrade/reconcilers"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // nolint:unused
@@ -78,7 +79,7 @@ func (r *ReleaseValidator) ValidateCreate(ctx context.Context, release *lifecycl
 	}
 
 	if release.Spec.ComponentConfig != nil {
-		if err := validateHelmValuesSecretExists(r.client, ctx, release.Spec.ComponentConfig.Helm); err != nil {
+		if err := validateHelmValuesSecret(r.client, ctx, release.Spec.ComponentConfig.Helm); err != nil {
 			return nil, err
 		}
 	}
@@ -116,7 +117,7 @@ func (r *ReleaseValidator) ValidateUpdate(ctx context.Context, oldRelease, newRe
 	}
 
 	if newRelease.Spec.ComponentConfig != nil {
-		if err := validateHelmValuesSecretExists(r.client, ctx, newRelease.Spec.ComponentConfig.Helm); err != nil {
+		if err := validateHelmValuesSecret(r.client, ctx, newRelease.Spec.ComponentConfig.Helm); err != nil {
 			return nil, err
 		}
 	}
@@ -165,28 +166,31 @@ func validateReleaseVersion(releaseVersion string) (*version.Version, error) {
 	return v, nil
 }
 
-// validateHelmValuesSecretExists validates that all Secrets defined in the given chart configuration
-// exist inside the "kube-system" namespace.
-func validateHelmValuesSecretExists(c client.Client, ctx context.Context, chartConfig []lifecyclev1alpha1.ChartConfig) error {
+// validateHelmValuesSecret ensures that all user provided chart value secrets
+// are present on the cluster and are containing the desired secret keys.
+func validateHelmValuesSecret(c client.Client, ctx context.Context, chartConfig []lifecyclev1alpha1.ChartConfig) error {
 	for _, chart := range chartConfig {
 		if chart.ValuesFrom.SecretRef != nil {
 			secretName := chart.ValuesFrom.SecretRef.Name
-			exists, err := validateSecretExists(c, ctx, types.NamespacedName{Name: secretName, Namespace: reconcilers.HelmChartNamespace})
-			if err != nil {
-				return fmt.Errorf("cannot verify existence of secret %q: %w", secretName, err)
+			secretNN := types.NamespacedName{
+				Name:      secretName,
+				Namespace: reconcilers.HelmChartNamespace,
 			}
 
-			if !exists {
-				return fmt.Errorf("chart %q references a %q secret that is missing from the %q namespace", chart.Chart, secretName, reconcilers.HelmChartNamespace)
+			existing := &corev1.Secret{}
+			if err := c.Get(ctx, secretNN, existing); err != nil {
+				if apierrors.IsNotFound(err) {
+					return fmt.Errorf("chart %q references a %q secret that is missing from the %q namespace", chart.Chart, secretName, reconcilers.HelmChartNamespace)
+				}
+				return fmt.Errorf("retrieving secret %q: %w", secretName, err)
+			}
+
+			for _, key := range chart.ValuesFrom.SecretRef.Keys {
+				if _, ok := existing.Data[key]; !ok {
+					return fmt.Errorf("chart %q references a %q key that is missing from the %q secret", chart.Chart, key, secretName)
+				}
 			}
 		}
 	}
-
 	return nil
-}
-
-// validateSecretExists validates whether a Secret exists in the given namespace.
-func validateSecretExists(c client.Client, ctx context.Context, nn types.NamespacedName) (bool, error) {
-	err := c.Get(ctx, nn, &corev1.Secret{})
-	return err == nil, client.IgnoreNotFound(err)
 }

--- a/internal/webhook/v1alpha1/release_webhook_test.go
+++ b/internal/webhook/v1alpha1/release_webhook_test.go
@@ -32,12 +32,13 @@ import (
 )
 
 const (
-	testNamespace      = "default"
-	testRegistry       = "registry.example.com"
-	testReleaseName    = "release"
-	testReleaseVersion = "0.5.0"
-	testChartName      = "test-chart"
-	existingSecretName = "existing-secret"
+	testNamespace        = "default"
+	testRegistry         = "registry.example.com"
+	testReleaseName      = "release"
+	testReleaseVersion   = "0.5.0"
+	updateReleaseVersion = "1.0.1"
+	testChartName        = "test-chart"
+	existingSecretName   = "existing-secret"
 )
 
 var _ = Describe("Release Webhook", Ordered, func() {
@@ -129,6 +130,36 @@ var _ = Describe("Release Webhook", Ordered, func() {
 			err := k8sClient.Create(ctx, release)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(ContainSubstring("chart \"test-chart\" references a \"missing-secret\" secret that is missing from the \"kube-system\" namespace")))
+		})
+
+		It("Should be denied if ComponentConfig references a missing secret key", func() {
+			release := &lifecyclev1alpha1.Release{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testReleaseName,
+					Namespace: testNamespace,
+				},
+				Spec: lifecyclev1alpha1.ReleaseSpec{
+					Registry: testRegistry,
+					Version:  testReleaseVersion,
+					ComponentConfig: &lifecyclev1alpha1.ComponentConfig{
+						Helm: []lifecyclev1alpha1.ChartConfig{
+							{
+								Chart: testChartName,
+								ValuesFrom: lifecyclev1alpha1.ChartValuesFrom{
+									SecretRef: &lifecyclev1alpha1.SecretValueSource{
+										Name: existingSecretName,
+										Keys: []string{"valeus.yaml"},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			err := k8sClient.Create(ctx, release)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring("chart \"test-chart\" references a \"valeus.yaml\" key that is missing from the \"existing-secret\" secret")))
 		})
 
 		It("Should admit if all fields are defined correctly", func() {
@@ -257,7 +288,7 @@ var _ = Describe("Release Webhook", Ordered, func() {
 		})
 
 		It("Should be denied if ComponentConfig references a missing secret", func() {
-			release.Spec.Version = "1.0.1"
+			release.Spec.Version = updateReleaseVersion
 			release.Spec.ComponentConfig = &lifecyclev1alpha1.ComponentConfig{
 				Helm: []lifecyclev1alpha1.ChartConfig{
 					{
@@ -277,8 +308,29 @@ var _ = Describe("Release Webhook", Ordered, func() {
 			Expect(err).To(MatchError(ContainSubstring("chart \"test-chart\" references a \"missing-secret\" secret that is missing from the \"kube-system\" namespace")))
 		})
 
+		It("Should be denied if ComponentConfig references a missing secret key", func() {
+			release.Spec.Version = updateReleaseVersion
+			release.Spec.ComponentConfig = &lifecyclev1alpha1.ComponentConfig{
+				Helm: []lifecyclev1alpha1.ChartConfig{
+					{
+						Chart: testChartName,
+						ValuesFrom: lifecyclev1alpha1.ChartValuesFrom{
+							SecretRef: &lifecyclev1alpha1.SecretValueSource{
+								Name: existingSecretName,
+								Keys: []string{"valeus.yaml"},
+							},
+						},
+					},
+				},
+			}
+
+			err := k8sClient.Update(ctx, release)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring("chart \"test-chart\" references a \"valeus.yaml\" key that is missing from the \"existing-secret\" secret")))
+		})
+
 		It("Should pass if the new release version is higher than the last applied one", func() {
-			release.Spec.Version = "1.0.1"
+			release.Spec.Version = updateReleaseVersion
 			Expect(k8sClient.Update(ctx, release)).To(Succeed())
 		})
 


### PR DESCRIPTION
Currently LCM validates the existence of any user defined Helm value secrets, but it does not validate whether the user defined secret keys actually exist in the secret. This causes any errors related to user misconfiguration to surface much later on Helm Controller level, where pinpointing the exact cause of the error is much harder.

The suggested changes enhance LCM's validation webhook, so that it is able to verify both the secret's existence and its contents. With this, any user misconfigurations will be handled before the `Release` resource is deployed, allowing for a better user experience and ensuring that no upgrade process is prematurely started.

**Example for a missing secret error:**

```yaml
# Release resource
...
spec:
  componentConfiguration:
    helm:
    - chart: cert-manager
      valuesFrom:
        secretRef:
          name: custom-values
          keys:
          - "values-cert-manager"
```

Validation output:

```bash
... admission webhook "vrelease.kb.io" denied the request: chart "cert-manager" references a "custom-values" secret that is missing from the "kube-system" namespace
```

**Example for a missing secret key error:**

```yaml
# Secret resource
apiVersion: v1
kind: Secret
metadata:
  name: custom-values
  namespace: kube-system
type: Opaque
stringData:
  values-cert-manager: |-
    replicaCount: 3
---
# Release resource
...
spec:
  componentConfiguration:
    helm:
    - chart: cert-manager
      valuesFrom:
        secretRef:
          name: custom-values
          keys:
          - "values-cert-manager22"
```

Valudation output:

```bash
... admission webhook "vrelease.kb.io" denied the request: chart "cert-manager" references a "values-cert-manager22" key that is missing from the "custom-values" secret
```