### PR TITLE
Fail for unknown helm component configurations

### DIFF
--- a/internal/controller/condition.go
+++ b/internal/controller/condition.go
@@ -37,21 +37,24 @@ func setCondition(release *lifecyclev1alpha1.Release, conditionType string, stat
 	})
 }
 
-// initializePendingConditions sets pending conditions for both the manifest and upgrade phases.
+// initializePendingConditions marks all upgrade relevant conditions as pending.
 func initializePendingConditions(release *lifecyclev1alpha1.Release, phases []upgrade.Phase) {
-	existing := apimeta.FindStatusCondition(release.Status.Conditions, lifecyclev1alpha1.ConditionManifestResolved)
-	if existing == nil {
+	if apimeta.FindStatusCondition(release.Status.Conditions, lifecyclev1alpha1.ConditionManifestResolved) == nil {
 		setCondition(release, lifecyclev1alpha1.ConditionManifestResolved, metav1.ConditionFalse,
 			lifecyclev1alpha1.UpgradePending, "Waiting for release manifest to be resolved")
 	}
 
 	for _, phase := range phases {
 		conditionType := phase.ConditionType()
-		existing := apimeta.FindStatusCondition(release.Status.Conditions, conditionType)
-		if existing == nil {
+		if apimeta.FindStatusCondition(release.Status.Conditions, conditionType) == nil {
 			setCondition(release, conditionType, metav1.ConditionFalse,
 				lifecyclev1alpha1.UpgradePending, "Waiting for previous phases to complete")
 		}
+	}
+
+	if apimeta.FindStatusCondition(release.Status.Conditions, lifecyclev1alpha1.ConditionApplied) == nil {
+		setCondition(release, lifecyclev1alpha1.ConditionApplied, metav1.ConditionFalse,
+			lifecyclev1alpha1.UpgradePending, "Upgrade pending")
 	}
 }
 
@@ -129,8 +132,5 @@ func updateAppliedCondition(release *lifecyclev1alpha1.Release, phases []upgrade
 	case inProgressPhase != "":
 		setCondition(release, lifecyclev1alpha1.ConditionApplied, metav1.ConditionFalse,
 			lifecyclev1alpha1.UpgradeInProgress, fmt.Sprintf("Phase %s is in progress", inProgressPhase))
-	default:
-		setCondition(release, lifecyclev1alpha1.ConditionApplied, metav1.ConditionFalse,
-			lifecyclev1alpha1.UpgradePending, "Upgrade pending")
 	}
 }

--- a/internal/controller/release_controller.go
+++ b/internal/controller/release_controller.go
@@ -126,6 +126,17 @@ func (r *ReleaseReconciler) reconcileNormal(ctx context.Context, release *lifecy
 
 	config, err := r.parseUpgradeConfig(ctx, manifest, release)
 	if err != nil {
+		var runtimeConfigErr upgrade.RuntimeConfigError
+		if errors.As(err, &runtimeConfigErr) {
+			// Use info-level logging rather than returning the error. Since the error is related to
+			// user misconfiguration, this ensures that the controller does not needlessly requeue
+			// until the user fixes the underlying configuration issue.
+			logger.Info("Invalid component configuration in Release resource", "error", runtimeConfigErr.Error())
+
+			setCondition(release, lifecyclev1alpha1.ConditionApplied, metav1.ConditionFalse,
+				lifecyclev1alpha1.UpgradeFailed, runtimeConfigErr.Error())
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, fmt.Errorf("parsing upgrade config: %w", err)
 	}
 

--- a/internal/upgrade/config.go
+++ b/internal/upgrade/config.go
@@ -19,6 +19,9 @@ package upgrade
 
 import (
 	"fmt"
+	"maps"
+	"slices"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/suse/elemental/v3/pkg/manifest/api"
@@ -85,6 +88,11 @@ type RuntimeConfig struct {
 	HelmCharts map[string]RuntimeHelmChartConfig
 }
 
+// RuntimeConfigError specifies an error caused due to invalid runtime configuration.
+type RuntimeConfigError string
+
+func (c RuntimeConfigError) Error() string { return string(c) }
+
 type RuntimeHelmChartConfig struct {
 	// Values specifies custom values provided by the user inline.
 	Values *apiextensionsv1.JSON
@@ -135,19 +143,27 @@ func NewConfig(manifest *resolver.ResolvedManifest, releaseVersion string, relea
 		DrainOpts: runtimeConfig.DrainOpts,
 	}
 
-	if manifest.SolutionExtension == nil {
-		config.HelmCharts = helmChartConfig(core.Components.Helm, nil, runtimeConfig.HelmCharts)
-	} else {
-		solution := manifest.SolutionExtension
-		config.HelmCharts = helmChartConfig(core.Components.Helm, solution.Components.Helm, runtimeConfig.HelmCharts)
+	var solutionCharts *api.Helm
+	if manifest.SolutionExtension != nil {
+		solutionCharts = manifest.SolutionExtension.Components.Helm
 	}
 
+	charts, err := helmChartConfig(core.Components.Helm, solutionCharts, runtimeConfig.HelmCharts)
+	if err != nil {
+		return nil, fmt.Errorf("parsing helm chart configuration: %w", err)
+	}
+
+	config.HelmCharts = charts
 	return config, nil
 }
 
-// helmChartConfig merges Helm configurations from core and solution manifests.
-func helmChartConfig(core, solution *api.Helm, runtimeConfigs map[string]RuntimeHelmChartConfig) []*HelmChartConfig {
+// helmChartConfig merges Helm configurations from the core and solution manifests with any runtime-defined overrides.
+func helmChartConfig(core, solution *api.Helm, runtimeConfigs map[string]RuntimeHelmChartConfig) ([]*HelmChartConfig, error) {
 	chartConfig := []*HelmChartConfig{}
+	unprocessedRuntimeCharts := make(map[string]struct{}, len(runtimeConfigs))
+	for chart := range runtimeConfigs {
+		unprocessedRuntimeCharts[chart] = struct{}{}
+	}
 
 	// Add core charts and repositories
 	if core != nil {
@@ -162,8 +178,9 @@ func helmChartConfig(core, solution *api.Helm, runtimeConfigs map[string]Runtime
 				config.Repository = repo
 			}
 
-			if runtimeConfigs, ok := runtimeConfigs[chart.Chart]; ok {
-				config.RuntimeConfig = runtimeConfigs
+			if rc, ok := runtimeConfigs[chart.Chart]; ok {
+				config.RuntimeConfig = rc
+				delete(unprocessedRuntimeCharts, chart.Chart)
 			}
 
 			chartConfig = append(chartConfig, config)
@@ -183,8 +200,9 @@ func helmChartConfig(core, solution *api.Helm, runtimeConfigs map[string]Runtime
 				config.Repository = repo
 			}
 
-			if runtimeConfigs, ok := runtimeConfigs[chart.Chart]; ok {
-				config.RuntimeConfig = runtimeConfigs
+			if rc, ok := runtimeConfigs[chart.Chart]; ok {
+				config.RuntimeConfig = rc
+				delete(unprocessedRuntimeCharts, chart.Chart)
 			}
 
 			chartConfig = append(chartConfig, config)
@@ -192,9 +210,15 @@ func helmChartConfig(core, solution *api.Helm, runtimeConfigs map[string]Runtime
 
 	}
 
-	if len(chartConfig) == 0 {
-		return nil
+	if len(unprocessedRuntimeCharts) > 0 {
+		// sort unknown slice to prevent status churn
+		unknown := slices.Sorted(maps.Keys(unprocessedRuntimeCharts))
+		return nil, RuntimeConfigError("Unknown chart references: " + strings.Join(unknown, ", "))
 	}
 
-	return chartConfig
+	if len(chartConfig) == 0 {
+		return nil, nil
+	}
+
+	return chartConfig, nil
 }

--- a/internal/upgrade/config_test.go
+++ b/internal/upgrade/config_test.go
@@ -18,6 +18,8 @@ limitations under the License.
 package upgrade
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/suse/elemental/v3/pkg/manifest/api"
@@ -98,6 +100,48 @@ var _ = Describe("Configuration creation", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("parsing OS image \"registry.com/foo:bar@broken@broken\": tag can only contain the characters"))
 	})
+
+	It("Should fail for unknown charts", func() {
+		manifest := &resolver.ResolvedManifest{
+			CorePlatform: &core.ReleaseManifest{
+				Components: core.Components{
+					OperatingSystem: &core.OperatingSystem{
+						Image: core.Image{
+							Base: baseOSImage,
+						},
+					},
+					Kubernetes: &core.Kubernetes{
+						Image:   k8sImage,
+						Version: k8sVersion,
+					},
+					Helm: &api.Helm{
+						Charts: []*api.HelmChart{
+							{Chart: "chart1"},
+							{Chart: "chart2"},
+						},
+					},
+				},
+			},
+		}
+
+		runtimeConfig := &RuntimeConfig{
+			HelmCharts: map[string]RuntimeHelmChartConfig{
+				"chart1":   {},
+				"unknown1": {},
+				"unknown2": {},
+				"chatr2":   {}},
+		}
+
+		_, err := NewConfig(manifest, "", types.NamespacedName{}, runtimeConfig)
+		Expect(err).To(HaveOccurred())
+
+		errSubstr := "Unknown chart references: "
+		Expect(err.Error()).To(ContainSubstring(errSubstr))
+		_, after, _ := strings.Cut(err.Error(), errSubstr)
+		unknownCharts := strings.Split(after, ", ")
+		Expect(unknownCharts).To(ConsistOf("unknown1", "unknown2", "chatr2"))
+	})
+
 	It("Should construct a correct upgrade configuration", func() {
 		resolvedManifest := &resolver.ResolvedManifest{CorePlatform: corePlatformManifest, SolutionExtension: solutionExtension}
 		runtimeSecretValues := &RuntimeSecretValueSource{


### PR DESCRIPTION
Currently LCM permits defining helm chart components that are missing from the specified release manifest, which leads to harder to detect user configuration errors.

The suggested changes ensure that any helm charts defined under `componentConfiguration.helm` exist in the specified release manifest. 

Charts defined by the user, but missing from the release manifest are treated as unknown charts and are reported under the `Applied` Release status condition. If any unknown charts are found, the upgrade process is stopped until the user mitigates the misconfigurations. This ensures that all configurations are correct before starting the actual upgrade process.

**Example:**
```yaml
# Release resource referencing a release manifest that 
# ships metallb, endpoint-copier-operator and cert-manager, 
# but user has misdefined the metallb and cert-manager charts.
...
spec:
  ...
  componentConfiguration:
    helm:
    - chart: metalbl
      ...
    - chart: endpoint-copier-operator
      ...
    - chart: cert-managr
      ...
status:
  conditions:
  - lastTransitionTime: "2026-07-14T09:11:02Z"
    message: Release manifest retrieved successfully
    observedGeneration: 1
    reason: Succeeded
    status: "True"
    type: ManifestResolved
  - lastTransitionTime: "2026-07-14T09:11:02Z"
    message: Waiting for previous phases to complete
    observedGeneration: 1
    reason: Pending
    status: "False"
    type: OSUpgraded
  ...
  - lastTransitionTime: "2026-07-14T09:11:02Z"
    message: 'Unknown chart references: metalbl, cert-managr'
    observedGeneration: 1
    reason: Failed
    status: "False"
    type: Applied
```
