### PR TITLE
No need to declare an empty and optional Metadata

### DIFF
--- a/internal/controller/release_controller_test.go
+++ b/internal/controller/release_controller_test.go
@@ -31,7 +31,6 @@ import (
 
 	lifecyclev1alpha1 "github.com/suse/elemental-lifecycle-manager/api/v1alpha1"
 	"github.com/suse/elemental-lifecycle-manager/internal/upgrade"
-	"github.com/suse/elemental/v3/pkg/manifest/api"
 	"github.com/suse/elemental/v3/pkg/manifest/api/core"
 	"github.com/suse/elemental/v3/pkg/manifest/resolver"
 )
@@ -75,7 +74,6 @@ var _ = Describe("Release Controller", func() {
 
 				return &resolver.ResolvedManifest{
 					CorePlatform: &core.ReleaseManifest{
-						Metadata: &api.Metadata{},
 						Components: core.Components{
 							OperatingSystem: &core.OperatingSystem{},
 							Kubernetes:      &core.Kubernetes{},


### PR DESCRIPTION
With this PR the changes from SUSE/elemental#528 are transparent to the code. I think this is good enough as it doesn't really change the test logic and it doesn't force us to immediately update the code to keep up with the latest SUSE/elemental, so we can bump the library whenever we see fit and rely on dependabot to bump it automatically without failures.