### PR TITLE
Fix SA1019 scheme.Builder deprecation lint error

### DIFF
--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -21,8 +21,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -34,7 +34,10 @@ var (
 	GroupVersion = SchemeGroupVersion
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
-	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}
+	// Register new types by adding them to the existing AddKnownTypes call
+	// in the relevant *_types.go file. Previous "SchemeBuilder.Register(&Foo{}, &FooList{})"
+	// scaffolding is no longer supported.
+	SchemeBuilder = &runtime.SchemeBuilder{}
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme

--- a/api/v1alpha1/release_types.go
+++ b/api/v1alpha1/release_types.go
@@ -23,6 +23,7 @@ import (
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // Label identification for a Release resource.
@@ -169,5 +170,9 @@ type ReleaseList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&Release{}, &ReleaseList{})
+	SchemeBuilder.Register(func(s *runtime.Scheme) error {
+		s.AddKnownTypes(SchemeGroupVersion, &Release{}, &ReleaseList{})
+		metav1.AddToGroupVersion(s, SchemeGroupVersion)
+		return nil
+	})
 }


### PR DESCRIPTION
With the version bump of controller-runtime from `0.20.3 -> 0.21.1` (#33) the `scheme.Builder` is deprecated and no longer supported. This causes our linter to produce the following `SA1019` error:

```go
api/v1alpha1/groupversion_info.go:37:19: SA1019: scheme.Builder is deprecated: This helper is only useful in api packages, but api packages should be easy to import and hence have minimal dependencies. Typically, these dependencies include only the standard library, k8s.io/apimachinery and other api packages. (staticcheck)
	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}
```

The suggested changes directly use the `apimachinery` library to register known types, fixing the linter errors in #67, #68, #69, #70 and #71.