### PR TITLE
Provide fixes for linter errors

### DIFF
--- a/internal/controller/condition.go
+++ b/internal/controller/condition.go
@@ -60,8 +60,7 @@ func initializePendingConditions(release *lifecyclev1alpha1.Release, phases []up
 
 // setPhaseConditionFromError sets a failed condition based on a PhaseError.
 func setPhaseConditionFromError(release *lifecyclev1alpha1.Release, err error) {
-	var phaseErr *upgrade.PhaseError
-	if errors.As(err, &phaseErr) {
+	if phaseErr, ok := errors.AsType[*upgrade.PhaseError](err); ok {
 		setCondition(release, phaseErr.Phase.ConditionType(), metav1.ConditionFalse,
 			lifecyclev1alpha1.UpgradeFailed, phaseErr.Err.Error())
 	}

--- a/internal/controller/release_controller.go
+++ b/internal/controller/release_controller.go
@@ -109,7 +109,7 @@ func (r *ReleaseReconciler) reconcileNormal(ctx context.Context, release *lifecy
 		release.Status.Conditions = nil
 		initializePendingConditions(release, r.Pipeline.Phases())
 
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: time.Second}, nil
 	}
 
 	defer updateAppliedCondition(release, r.Pipeline.Phases())

--- a/internal/controller/release_controller.go
+++ b/internal/controller/release_controller.go
@@ -126,8 +126,7 @@ func (r *ReleaseReconciler) reconcileNormal(ctx context.Context, release *lifecy
 
 	config, err := r.parseUpgradeConfig(ctx, manifest, release)
 	if err != nil {
-		var runtimeConfigErr upgrade.RuntimeConfigError
-		if errors.As(err, &runtimeConfigErr) {
+		if runtimeConfigErr, ok := errors.AsType[upgrade.RuntimeConfigError](err); ok {
 			// Use info-level logging rather than returning the error. Since the error is related to
 			// user misconfiguration, this ensures that the controller does not needlessly requeue
 			// until the user fixes the underlying configuration issue.


### PR DESCRIPTION
- Move away from `errors.As` in favour of `errors.AsType`
- Remove deprecated `Requeue: true` in favour of a scoped requeue after 1 second.

Fixes linter failures for: #89, #88, #87, #86 